### PR TITLE
Improve node probes checks

### DIFF
--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -42,7 +42,9 @@ helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm
 | Parameter                                | Description                                                                                                               | Default                        |
 |------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|--------------------------------|
 | `node.chain`                             | Network to connect the node to (ie `--chain`)                                                                             | `polkadot`                     |
-| `node.flags`                             | Node flags other than `--name` (set from the helm release name), `--base-path` and `--chain` (both set with `node.chain`) | `--prometheus-external --rpc-external --rpc-cors all` |
+| `node.flags`                             | Node flags other than `--name` (set from the helm release name), `--base-path` and `--chain` (both set with `node.chain`) | `--prometheus-external --rpc-external --ws-external --rpc-cors all` |
+| `node.enableStartupProbe`                | If true, enable the startup probe check                                                                           | `true`                         |
+| `node.enableReadinessProbe`              | If true, enable the readiness probe check                                                                         | `true`                         |
 | `node.dataVolumeSize`                    | The size of the chain data PersistentVolume                                                                               | `100Gi`                        |
 | `node.replica`                           | Number of replica in the node StatefulSet                                                                                 | `1`                            |
 | `node.chainDataSnapshotUrl`              | Download and load chain data from a snapshot archive http URL                                                             | ``                             |

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -130,16 +130,30 @@ spec:
             - containerPort: 30333
               name: p2p
               protocol: TCP
+          {{- if .Values.node.enableStartupProbe }}
+          # On startup, retry the connection to the /health endpoint every 10s for 5 min before killing the container
+          startupProbe:
+            failureThreshold: 30
+            periodSeconds: 10
+            # Use an exec command as Substate's default configuration only allow local network access to the RPC endpoint
+            exec:
+              command:
+              - curl
+              - "http://127.0.0.1:9933/health"
+          {{- end }}
+          {{- if .Values.node.enableReadinessProbe }}
+          # Continuously retry the connection to the WS endpoint every 10s for 24h until success before marking the container as ready
+          # If the WS endpoint is still not reachable (ie. node not fully synced) after 24 hours have passed, the container will be stuck in 'Not Ready' state
           readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /health
-              port: http-rpc
-              scheme: HTTP
+            failureThreshold: 8640
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+            # Important: the readiness probe will only work properly if the WS endpoint is exposed with --ws-external
+            tcpSocket:
+              port: websocket-rpc
+          {{- end }}
           resources:
           {{- toYaml .Values.node.resources | nindent 12 }}
           volumeMounts:

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -57,11 +57,13 @@ node:
   #chainPath: ""
   #chainDataKubernetesVolumeSnapshot: ""
   #chainDataGcsBucketUrl: ""
+  enableStartupProbe: true
+  enableReadinessProbe: true
   flags:
     - "--prometheus-external"
     - "--rpc-external"
-    - "--rpc-cors"
-    - "all"
+    - "--ws-external"
+    - "--rpc-cors=all"
   resources: {}
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
- add default startup probe (http check on /health every 10s for 5m)
- add readiness check (tcp socket check on the WS port every 10s for 24h)
- add --ws-external as default flag to make the readiness check work in the default config
- allow disabling the readiness check