### PR TITLE
adding substrate-telemetry helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Parity's [Kubernetes Helm](https://helm.sh/) charts collection.
 ## Charts list
 
 - [Node](charts/node/README.md): deploy Substrate/Polkadot nodes
+- [Substrate telemetry](charts/substrate-telemetry/README.md): deploy Substrate Telemetry for the nodes

--- a/charts/substrate-telemetry/.helmignore
+++ b/charts/substrate-telemetry/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/substrate-telemetry/Chart.yaml
+++ b/charts/substrate-telemetry/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: substrate-telemetry
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/substrate-telemetry/README.md
+++ b/charts/substrate-telemetry/README.md
@@ -1,0 +1,25 @@
+Helm# Substrate Telemetry Helm Chart
+
+The helm chart installs Telemetry-Core, Telemetry-Shard and Telemetry-Frontend services.  
+
+Substrate-Telemetry Github repo lives in https://github.com/paritytech/substrate-telemetry.
+
+## Installing the chart
+
+```console
+helm repo add parity https://paritytech.github.io/helm-charts/
+helm repo update
+helm install substrate-telemetry parity/substrate-telemetry
+```
+
+## Requirements
+By default, the type of Kubernetes service used for Telemetry-Core, Telemetry-Shard and Telemetry-Frontend is `ClusterIP`, so they're not accessible from outside of the k8s cluster. Consider exposing all of the services using service of type `LoadBalancer` or using an ingress controller:
+  - **Frontend**: This is the frontend web application for the backend services.
+  - **Shard**: Polkadot/Substrate nodes will submit their statistics to the `/submit` endpoint of the `Shard` service. It's recommended to only expose `/submit` endpoint.
+  - **Core**: This is where all of the data would be stored. The `/feed` should only be exposed to the public network as other endpoints might expose sensitive information about the nodes.
+
+**Notes**:
+- All the services must be exposed over `HTTPS`.
+- The `Core` service could also be exposed using the `Frontend` Nginx service. The Nginx configuration should be tweaked for this purpose.
+- Consider setting `.Values.envVars.frontend.SUBSTRATE_TELEMETRY_URL` variable otherwise the web clients wouldn't be able to find the `Core` service address.
+

--- a/charts/substrate-telemetry/templates/NOTES.txt
+++ b/charts/substrate-telemetry/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.shard.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "substrate-telemetry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.shard.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w telemetry-shard'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "substrate-telemetry.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.shard.port }}
+{{- else if contains "ClusterIP" .Values.service.shard.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "substrate-telemetry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/substrate-telemetry/templates/_helpers.tpl
+++ b/charts/substrate-telemetry/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "substrate-telemetry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "substrate-telemetry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "substrate-telemetry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "substrate-telemetry.labels" -}}
+helm.sh/chart: {{ include "substrate-telemetry.chart" . }}
+{{ include "substrate-telemetry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "substrate-telemetry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "substrate-telemetry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "substrate-telemetry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "substrate-telemetry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/core-deployment.yaml
+++ b/charts/substrate-telemetry/templates/core-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-core
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: core
+spec:
+  {{- if not .Values.autoscaling.core.enabled }}
+  replicas: {{ .Values.replicaCount.core }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "substrate-telemetry.selectorLabels" . | nindent 6 }}
+      telemetry-component: core
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "substrate-telemetry.selectorLabels" . | nindent 8 }}
+        telemetry-component: core
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "substrate-telemetry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
+          {{- if .Values.envVars.core }}
+          env:
+          {{- range $key, $val := .Values.envVars.core }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end }}
+          {{- end }}
+          command:
+            - "telemetry_core"
+          args:
+            - "--listen"
+            - "0.0.0.0:{{ .Values.service.core.targetPort }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.core.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/substrate-telemetry/templates/core-ingress.yaml
+++ b/charts/substrate-telemetry/templates/core-ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingress.core.enabled -}}
+{{- $fullName := include "substrate-telemetry.fullname" . -}}
+{{- $svcPort := .Values.service.core.port -}}
+{{- if and .Values.ingress.core.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.core.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.core.annotations "kubernetes.io/ingress.class" .Values.ingress.core.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: telemetry-core
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: core
+  {{- with .Values.ingress.core.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.core.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.core.className }}
+  {{- end }}
+  {{- if .Values.ingress.core.tls }}
+  tls:
+    {{- range .Values.ingress.core.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.core.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: telemetry-core
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: telemetry-core
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/core-service.yaml
+++ b/charts/substrate-telemetry/templates/core-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-core
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: core
+  annotations:
+    {{- toYaml .Values.service.core.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.core.type }}
+  ports:
+    - port: {{ .Values.service.core.port }}
+      targetPort: {{ .Values.service.core.targetPort }}
+      protocol: TCP
+      name: http
+{{- if (and (eq .Values.service.core.type "NodePort") (not (empty .Values.service.core.nodePort))) }}
+      nodePort: {{ .Values.service.core.nodePort }}
+{{- end }}
+  selector:
+    {{- include "substrate-telemetry.selectorLabels" . | nindent 4 }}
+    telemetry-component: core

--- a/charts/substrate-telemetry/templates/core-servicemonitor.yaml
+++ b/charts/substrate-telemetry/templates/core-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceMonitor.core.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: telemetry-core
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: core
+    {{- if .Values.serviceMonitor.core.additionalLabels }}
+{{ toYaml .Values.serviceMonitor.core.additionalLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.core.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.core.annotations | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "substrate-telemetry.selectorLabels" . | nindent 6 }}
+      telemetry-component: core
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http
+    {{- if .Values.serviceMonitor.core.interval }}
+    interval: {{ .Values.serviceMonitor.core.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.core.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.core.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/frontend-deployment.yaml
+++ b/charts/substrate-telemetry/templates/frontend-deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-frontend
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: frontend
+spec:
+  {{- if not .Values.autoscaling.frontend.enabled }}
+  replicas: {{ .Values.replicaCount.frontend }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "substrate-telemetry.selectorLabels" . | nindent 6 }}
+      telemetry-component: frontend
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "substrate-telemetry.selectorLabels" . | nindent 8 }}
+        telemetry-component: frontend
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "substrate-telemetry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
+          {{- if .Values.envVars.frontend }}
+          env:
+          {{- range $key, $val := .Values.envVars.frontend }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.frontend.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/substrate-telemetry/templates/frontend-hpa.yaml
+++ b/charts/substrate-telemetry/templates/frontend-hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.autoscaling.frontend.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: telemetry-frontend
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: telemetry-frontend
+  minReplicas: {{ .Values.autoscaling.frontend.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.frontend.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.frontend.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.frontend.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.frontend.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.frontend.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/frontend-ingress.yaml
+++ b/charts/substrate-telemetry/templates/frontend-ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingress.frontend.enabled -}}
+{{- $fullName := include "substrate-telemetry.fullname" . -}}
+{{- $svcPort := .Values.service.frontend.port -}}
+{{- if and .Values.ingress.frontend.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.frontend.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.frontend.annotations "kubernetes.io/ingress.class" .Values.ingress.frontend.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: telemetry-frontend
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: frontend
+  {{- with .Values.ingress.frontend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.frontend.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.frontend.className }}
+  {{- end }}
+  {{- if .Values.ingress.frontend.tls }}
+  tls:
+    {{- range .Values.ingress.frontend.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.frontend.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: telemetry-frontend
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: telemetry-frontend
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/frontend-service.yaml
+++ b/charts/substrate-telemetry/templates/frontend-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-frontend
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: frontend
+  annotations:
+    {{- toYaml .Values.service.frontend.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.frontend.type }}
+  ports:
+    - port: {{ .Values.service.frontend.port }}
+      targetPort: {{ .Values.service.frontend.targetPort }}
+      protocol: TCP
+      name: http
+{{- if (and (eq .Values.service.frontend.type "NodePort") (not (empty .Values.service.frontend.nodePort))) }}
+      nodePort: {{ .Values.service.frontend.nodePort }}
+{{- end }}
+  selector:
+    {{- include "substrate-telemetry.selectorLabels" . | nindent 4 }}
+    telemetry-component: frontend

--- a/charts/substrate-telemetry/templates/serviceaccount.yaml
+++ b/charts/substrate-telemetry/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "substrate-telemetry.serviceAccountName" . }}
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/shard-deployment.yaml
+++ b/charts/substrate-telemetry/templates/shard-deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telemetry-shard
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: shard
+spec:
+  {{- if not .Values.autoscaling.shard.enabled }}
+  replicas: {{ .Values.replicaCount.shard }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "substrate-telemetry.selectorLabels" . | nindent 6 }}
+      telemetry-component: shard
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "substrate-telemetry.selectorLabels" . | nindent 8 }}
+        telemetry-component: shard
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "substrate-telemetry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
+          {{- if .Values.envVars.shard }}
+          env:
+          {{- range $key, $val := .Values.envVars.shard }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end }}
+          {{- end }}
+          command:
+            - "telemetry_shard"
+          args:
+            - "--listen"
+            - "0.0.0.0:{{ .Values.service.shard.targetPort }}"
+            - "--core"
+            - "http://telemetry-core:{{ .Values.service.core.port }}/shard_submit"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.shard.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/substrate-telemetry/templates/shard-hpa.yaml
+++ b/charts/substrate-telemetry/templates/shard-hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.autoscaling.shard.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: telemetry-shard
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: shard
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: telemetry-shard
+  minReplicas: {{ .Values.autoscaling.shard.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.shard.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.shard.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.shard.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.shard.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.shard.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/shard-ingress.yaml
+++ b/charts/substrate-telemetry/templates/shard-ingress.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.ingress.shard.enabled -}}
+{{- $fullName := include "substrate-telemetry.fullname" . -}}
+{{- $svcPort := .Values.service.shard.port -}}
+{{- if and .Values.ingress.shard.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.shard.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.shard.annotations "kubernetes.io/ingress.class" .Values.ingress.shard.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: telemetry-shard
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: shard
+  {{- with .Values.ingress.shard.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.shard.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.shard.className }}
+  {{- end }}
+  {{- if .Values.ingress.shard.tls }}
+  tls:
+    {{- range .Values.ingress.shard.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.shard.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: telemetry-shard
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: telemetry-shard
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/substrate-telemetry/templates/shard-service.yaml
+++ b/charts/substrate-telemetry/templates/shard-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-shard
+  labels:
+    {{- include "substrate-telemetry.labels" . | nindent 4 }}
+    telemetry-component: shard
+  annotations:
+    {{- toYaml .Values.service.shard.annotations | nindent 4 }}
+
+spec:
+  type: {{ .Values.service.shard.type }}
+  ports:
+    - port: {{ .Values.service.shard.port }}
+      targetPort: {{ .Values.service.shard.targetPort }}
+      protocol: TCP
+      name: http
+{{- if (and (eq .Values.service.shard.type "NodePort") (not (empty .Values.service.shard.nodePort))) }}
+      nodePort: {{ .Values.service.shard.nodePort }}
+{{- end }}
+  selector:
+    {{- include "substrate-telemetry.selectorLabels" . | nindent 4 }}
+    telemetry-component: shard

--- a/charts/substrate-telemetry/values.yaml
+++ b/charts/substrate-telemetry/values.yaml
@@ -1,0 +1,160 @@
+# Default values for substrate-telemtry.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+replicaCount:
+  # NOTE: The core service is not scalable at the moment.
+  shard: 1
+  core: 1
+  frontend: 1
+
+image:
+  backend:
+    repository: docker.io/parity/substrate-telemetry-backend
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: latest
+  frontend:
+    repository: docker.io/parity/substrate-telemetry-frontend
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+envVars:
+  shard: {}
+  core: {}
+  frontend:
+    # The frontend docker container makes this available to the UI,
+    # so that it knows where to look for feed information:
+    SUBSTRATE_TELEMETRY_URL: "wss://core-service-domain.com"
+
+serviceMonitor:
+  # Only core service has Prometheus metrics exposed at the moment.
+  core:
+    enabled: false
+    interval: ""
+    additionalLabels: {}
+    annotations: {}
+    # scrapeTimeout: 10s
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  shard:
+    type: ClusterIP
+    port: 80
+    targetPort: 8000
+    # nodePort: 31000
+    annotations: {}
+  core:
+    type: ClusterIP
+    port: 80
+    targetPort: 8000
+    # nodePort: 31000
+    annotations: {}
+  frontend:
+    type: ClusterIP
+    port: 80
+    targetPort: 8000
+    # nodePort: 31000
+    annotations: {}
+
+ingress:
+  shard:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: chart-example-tls
+        hosts:
+          - chart-example.local
+  core:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example-1.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: chart-example-tls
+        hosts:
+          - chart-example-1.local
+  frontend:
+    enabled: false
+    className: ""
+    annotations:
+    hosts:
+      - host: chart-example-1.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: chart-example-tls
+        hosts:
+          - chart-example.local
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  # NOTE: The core service is not scalable at the moment.
+  shard:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  frontend:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  core:
+    enabled: false
+
+nodeSelector: {}
+affinity: {}
+tolerations: []


### PR DESCRIPTION
according to the conversation on  https://github.com/paritytech/substrate-telemetry/pull/368, a new generic helm chart is created for the `minikube` users or everyone that have a basic Kubernetes cluster running without fancy features we have on our clusters.
This helm chart is meant to be a basic installation for telemetry service on every Kubernetes cluster. The readme has some notes for public users who want to run their own telemetry instance.