### PR TITLE
Set external traffic policy to local for node port services

### DIFF
--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -51,6 +51,7 @@ metadata:
   name: {{ $fullname }}-{{ $i }}-p2p
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   selector:
     {{- $selectorLabels | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}


### PR DESCRIPTION
To help with connecting to nodes p2p ports directly without traffic being shifted between nodes by kubernetes.

From [Kubernetes Reference Service API v1](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#service-v1-core):

> externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.

