### PR TITLE
P2P address auto discovery

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: "0.0.1"

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullname }}-{{ $i }}-p2p
+  name: {{ $fullname }}-{{ $i }}-relay-chain-p2p
 spec:
   type: NodePort
   externalTrafficPolicy: Local
@@ -57,8 +57,8 @@ spec:
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
   ports:
     - name: p2p
-      port: {{ add $.Values.node.perNodeServices.p2pNodePortStartRange $i }}
-      nodePort: {{ add $.Values.node.perNodeServices.p2pNodePortStartRange $i }}
+      port: 30333
+      targetPort: 30333
 {{- end }}
 ---
 {{ end }}

--- a/charts/node/templates/serviceAccount.yaml
+++ b/charts/node/templates/serviceAccount.yaml
@@ -1,12 +1,36 @@
+{{ $serviceAccountName :=  include "chart.serviceAccountName" . }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "chart.serviceAccountName" . }}
+  name: {{ $serviceAccountName }}
   labels:
   {{- include "chart.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- end }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $serviceAccountName }}-service-reader
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+---
+# Allow the {{ include "chart.serviceAccountName" . }}-service-port-retriever service account to read services in the {{ .Release.Namespace }} namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $serviceAccountName }}-service-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $serviceAccountName }}-service-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ $serviceAccountName }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -184,6 +184,7 @@ spec:
                 {{- end }}
                 --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
                 {{- end }}
+                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
                 {{- if .Values.node.persistGeneratedNodeKey }}
                 --node-key-file /data/node-key \
                 {{- end }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -113,37 +113,57 @@ spec:
             - mountPath: /data
               name: chain-data
         {{- end }}
-      {{- if .Values.node.keys }}
-      - name: inject-keys
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        command: [ "/bin/sh" ]
-        args:
-          - -c
-          - |
-            {{- range $index, $key := .Values.node.keys }}
-            echo {{ $key.seed }} > /dev/shm/{{ $index }}.key
-            {{ .Values.node.command }} key insert --base-path /data --chain ${CHAIN} --key-type {{ $key.type }} --scheme {{ $key.scheme }} --suri /dev/shm/{{ $index }}.key
-            rm /dev/shm/{{ $index }}.key
-            {{- end }}
-        env:
-          - name: CHAIN
-            value: {{ .Values.node.chain }}
-        volumeMounts:
-          - mountPath: /data
-            name: chain-data
-      {{- end }}
-      containers:
-        - name: {{ .Values.node.chain }}
+        {{- if .Values.node.keys }}
+        - name: inject-keys
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.node.perNodeServices.createP2pNodePortService }}
           command: [ "/bin/sh" ]
           args:
             - -c
             - |
+              {{- range $index, $key := .Values.node.keys }}
+              echo {{ $key.seed }} > /dev/shm/{{ $index }}.key
+              {{ .Values.node.command }} key insert --base-path /data --chain ${CHAIN} --key-type {{ $key.type }} --scheme {{ $key.scheme }} --suri /dev/shm/{{ $index }}.key
+              rm /dev/shm/{{ $index }}.key
+              {{- end }}
+          env:
+            - name: CHAIN
+              value: {{ .Values.node.chain }}
+          volumeMounts:
+            - mountPath: /data
+              name: chain-data
+        {{- end }}
+        {{- if .Values.node.perNodeServices.createP2pNodePortService }}
+        - name: retrieve-node-port
+          image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+          command: [ "/bin/sh" ]
+          args:
+            - -c
+            - |
+              EXTERNAL_IP=$(curl {{ .Values.kubectl.ipRetrievalServiceUrl }})
+              echo "${EXTERNAL_IP}" > /data/node_external_ip
+              echo "Retrieved external IP from {{ .Values.kubectl.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
               POD_INDEX="${HOSTNAME##*-}"
-              P2P_PORT=$(({{ .Values.node.perNodeServices.p2pNodePortStartRange }}+POD_INDEX))
-              echo "P2P_PORT=${P2P_PORT}"
+              RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
+              echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
+              echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-relay-chain-p2p, saved ${RELAY_CHAIN_P2P_PORT} to /data/relay_chain_p2p_port"
+          volumeMounts:
+            - mountPath: /data
+              name: chain-data
+        {{- end }}
+      containers:
+        - name: {{ .Values.node.chain }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/bin/sh" ]
+          args:
+            - -c
+            - |
+              {{- if .Values.node.perNodeServices.createP2pNodePortService }}
+              EXTERNAL_IP="$(cat /data/node_external_ip)"
+              echo "EXTERNAL_IP=${EXTERNAL_IP}"
+              RELAY_CHAIN_P2P_PORT="$(cat /data/relay_chain_p2p_port)"
+              echo "RELAY_CHAIN_P2P_PORT=${RELAY_CHAIN_P2P_PORT}"
+              {{- end }}
               exec {{ .Values.node.command }} \
                 --name=${POD_NAME} \
                 --base-path=/data/ \
@@ -154,7 +174,10 @@ spec:
                 {{- if eq .Values.node.role "light" }}
                 --light \
                 {{- end }}
-                --listen-addr={{ .Values.node.perNodeServices.listenAddressBase }}${P2P_PORT} \
+                {{- if .Values.node.perNodeServices.createP2pNodePortService }}
+                --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT} \
+                {{- end }}
+                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
                 {{- if .Values.node.persistGeneratedNodeKey }}
                 --node-key-file /data/node-key \
                 {{- end }}
@@ -162,25 +185,6 @@ spec:
                 --jaeger-agent=127.0.0.1:{{ .Values.jaegerAgent.ports.compactPort }} \
                 {{- end }}
                 {{- join " " .Values.node.flags | nindent 16 }}
-          {{- else }}
-          args:
-            - --name=$(POD_NAME)
-            - --base-path=/data/
-            - --chain={{ if .Values.node.customChainspecUrl }}/data/chainspec.json{{ else }}$(CHAIN){{ end }}
-            {{- if eq .Values.node.role "authority" }}
-            - --validator
-            {{- end }}
-            {{- if eq .Values.node.role "light" }}
-            - --light \
-            {{- end }}
-            {{- if .Values.node.persistGeneratedNodeKey }}
-            - --node-key-file=/data/node-key
-            {{- end }} 
-            {{- if .Values.node.tracing.enabled }}
-            - --jaeger-agent=127.0.0.1:{{ .Values.jaegerAgent.ports.compactPort }}
-            {{- end }}
-            {{- toYaml .Values.node.flags | nindent 12 }}
-          {{- end }}
           env:
             - name: CHAIN
               value: {{ .Values.node.chain }}
@@ -251,7 +255,7 @@ spec:
           image: {{ .Values.jaegerAgent.image.repository }}:{{ .Values.jaegerAgent.image.tag }}
           args:
             - --reporter.grpc.host-port={{ .Values.jaegerAgent.collector.url }}:{{ .Values.jaegerAgent.collector.port }}
-          env: 
+          env:
             {{- range $key, $val := .Values.jaegerAgent.env }}
             - name: {{ $key }}
               value: {{ $val }}
@@ -280,7 +284,7 @@ spec:
               path: /
               port: admin
         {{- end}}
-      serviceAccountName: {{ $serviceAccountName}}
+      serviceAccountName: {{ $serviceAccountName }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -139,9 +139,9 @@ spec:
           args:
             - -c
             - |
-              EXTERNAL_IP=$(curl {{ .Values.kubectl.ipRetrievalServiceUrl }})
+              EXTERNAL_IP=$(curl {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }})
               echo "${EXTERNAL_IP}" > /data/node_external_ip
-              echo "Retrieved external IP from {{ .Values.kubectl.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
+              echo "Retrieved external IP from {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -139,13 +139,15 @@ spec:
           args:
             - -c
             - |
-              EXTERNAL_IP=$(curl {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }})
-              echo "${EXTERNAL_IP}" > /data/node_external_ip
-              echo "Retrieved external IP from {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
               echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-relay-chain-p2p, saved ${RELAY_CHAIN_P2P_PORT} to /data/relay_chain_p2p_port"
+              {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
+              EXTERNAL_IP=$(curl {{ .Values.node.perNodeServices.setPublicAddressToExternalIp.ipRetrievalServiceUrl }})
+              echo "${EXTERNAL_IP}" > /data/node_external_ip
+              echo "Retrieved external IP from {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
+              {{- end }}
           volumeMounts:
             - mountPath: /data
               name: chain-data
@@ -159,8 +161,10 @@ spec:
             - -c
             - |
               {{- if .Values.node.perNodeServices.createP2pNodePortService }}
+              {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
               EXTERNAL_IP="$(cat /data/node_external_ip)"
               echo "EXTERNAL_IP=${EXTERNAL_IP}"
+              {{- end }}
               RELAY_CHAIN_P2P_PORT="$(cat /data/relay_chain_p2p_port)"
               echo "RELAY_CHAIN_P2P_PORT=${RELAY_CHAIN_P2P_PORT}"
               {{- end }}
@@ -175,9 +179,11 @@ spec:
                 --light \
                 {{- end }}
                 {{- if .Values.node.perNodeServices.createP2pNodePortService }}
+                {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
                 --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT} \
                 {{- end }}
-                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
+                --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
+                {{- end }}
                 {{- if .Values.node.persistGeneratedNodeKey }}
                 --node-key-file /data/node-key \
                 {{- end }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -8,6 +8,12 @@ initContainer:
     repository: crazymax/7zip
     tag: latest
 
+kubectl:
+  image:
+    repository: bitnami/kubectl
+    tag: latest
+  ipRetrievalServiceUrl: https://ifconfig.io
+
 googleCloudSdk:
   image:
     repository: google/cloud-sdk
@@ -83,9 +89,6 @@ node:
   perNodeServices:
     createClusterIPService: true
     createP2pNodePortService: false
-    p2pNodePortStartRange: "30000"
-    # Set to 0.0.0.0 to enable auto discovery of the IP address
-    listenAddressBase: "/ip4/0.0.0.0/tcp/"
   #podManagementPolicy: Parallel
   #customChainspecUrl:
 
@@ -93,7 +96,7 @@ node:
   tracing:
     enabled: false
 
-  # Enables Sustrate API as a sidecar 
+  # Enables Sustrate API as a sidecar
   substrateApiSidecar:
     enabled: false
 
@@ -122,7 +125,7 @@ jaegerAgent:
     # Jaeger Default GRPC port is 14250
     port: 14250
   env: {}
-  resources: {}      
+  resources: {}
 
 podAnnotations: {}
 

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -12,7 +12,6 @@ kubectl:
   image:
     repository: bitnami/kubectl
     tag: latest
-  ipRetrievalServiceUrl: https://ifconfig.io
 
 googleCloudSdk:
   image:
@@ -89,6 +88,7 @@ node:
   perNodeServices:
     createClusterIPService: true
     createP2pNodePortService: false
+    ipRetrievalServiceUrl: https://ifconfig.io
   #podManagementPolicy: Parallel
   #customChainspecUrl:
 

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -88,7 +88,9 @@ node:
   perNodeServices:
     createClusterIPService: true
     createP2pNodePortService: false
-    ipRetrievalServiceUrl: https://ifconfig.io
+    setPublicAddressToExternalIp:
+      enabled: false
+      ipRetrievalServiceUrl: https://ifconfig.io
   #podManagementPolicy: Parallel
   #customChainspecUrl:
 


### PR DESCRIPTION
Implement a new way of configuring the node external p2p address exposed on a Kubernetes nodePort service.

- Auto-discover the external port, by querying the kubernetes service to retrieve the attributed node port
- Auto-discover the external ip address from a third party service such as ifconfig.io (optional, shouldn't be needed if Kubernetes nodes have public IPs as it should be autodiscovered by libp2p)