### PR TITLE
Add support for moonriver-based collators

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 0.24.1
+version: 0.24.2
 appVersion: "0.0.1"

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 0.24.2
+version: 0.24.3
 appVersion: "0.0.1"

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -173,13 +173,13 @@ spec:
             - -c
             - |
               {{- if .Values.node.customChainspecUrl }}
-              if [ ! -f /data/chainspec.json ]; then
-                wget -O /data/chainspec.json {{ .Values.node.customChainspecUrl }}
+              if [ ! -f {{ .Values.node.customChainspecPath }} ]; then
+                wget -O {{ .Values.node.customChainspecPath }} {{ .Values.node.customChainspecUrl }}
               fi
               {{- end }}
               {{- if .Values.node.collator.relayChainCustomChainspecUrl }}
-              if [ ! -f /data/relay_chain_chainspec.json ]; then
-                wget -O /data/relay_chain_chainspec.json {{ .Values.node.collator.relayChainCustomChainspecUrl }}
+              if [ ! -f {{ .Values.node.relayChainCustomChainspecPath }} ]; then
+                wget -O {{ .Values.node.relayChainCustomChainspecPath }} {{ .Values.node.collator.relayChainCustomChainspecUrl }}
               fi
               {{- end }}
           volumeMounts:
@@ -261,7 +261,7 @@ spec:
               exec {{ .Values.node.command }} \
                 --name=${POD_NAME} \
                 --base-path=/data/ \
-                --chain={{ if .Values.node.customChainspecUrl }}/data/chainspec.json{{ else }}${CHAIN}{{ end }} \
+                --chain={{ if .Values.node.customChainspecUrl }}{{ .Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
                 {{- if or (eq .Values.node.role "authority") (eq .Values.node.role "validator") }}
                 --validator \
                 {{- end }}
@@ -294,7 +294,7 @@ spec:
                 --base-path=/data/relay/ \
                 {{- end }}
                 {{- if .Values.node.collator.relayChainCustomChainspecUrl }}
-                --chain=/data/relay_chain_chainspec.json \
+                --chain={{ .Values.node.relayChainCustomChainspecPath }} \
                 {{- end }}
                 {{- if .Values.node.perNodeServices.createP2pNodePortService }}
                 {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -62,6 +62,9 @@ node:
   replicas: 1
   role: full
   #customChainspecUrl:
+  ## Node may require custom name for chainspec file. Example: moonbeam https://github.com/PureStake/moonbeam/issues/1104#issuecomment-996787548
+  ## Note: path should start with /data/ since this folder mount in init container download-chainspec.
+  customChainspecPath: "/data/chainspec.json"
   #chainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
   #chainDataSnapshotFormat: 7z
   #chainPath: ""
@@ -71,6 +74,7 @@ node:
      isParachain: false
      relayChain: polkadot
   #  relayChainCustomChainspecUrl: ""
+  relayChainCustomChainspecPath: "/data/relay_chain_chainspec.json"
   #  relayChainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
   #  relayChainDataSnapshotFormat: 7z
   #  relayChainPath: ""


### PR DESCRIPTION
Moonriver-based collators use chainspec file names to define internal logic (see: https://github.com/PureStake/moonbeam/issues/1104#issuecomment-996787548 )
In current version of  helm chart chainspec the  file name is hard-coded to `/data/chainspec.json`
This PR adds support for such nodes, by allowing users to change the name of chainspec file. 

The variable `customChainspecPath` should contain the full path to chainspec inside a container. The reason why I moved full path to a variable, not just name because in the future we may add the feature to set chain spec as `configmap` and we should  be able to use this value. (However, is unlikely due to `configmap` size limit of 1MB.)

This change is backward compatible since it sets the default name to the old value. 
