### PR TITLE
Renamed helper templates in node chart

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 0.24.3
+version: 1.0.0
 appVersion: "0.0.1"

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -28,8 +28,8 @@ helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm
 
 | Parameter           | Description                                  | Default                        |
 |---------------------|----------------------------------------------|--------------------------------|
-| `nameOverride`      | String to partially override chart.fullname  | `nil`                          |
-| `fullnameOverride`  | String to fully override chart.fullname      | `nil`                          |
+| `nameOverride`      | String to partially override node.fullname   | `nil`                          |
+| `fullnameOverride`  | String to fully override node.fullname       | `nil`                          |
 | `imagePullSecrets`  | Labels to add to all deployed objects        | `[]`                           |
 | `podAnnotations`    | Annotations to add to pods                   | `{}` (evaluated as a template) |
 | `nodeSelector`      | Node labels for pod assignment               | `{}` (evaluated as a template) |

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
+{{- define "node.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart.fullname" -}}
+{{- define "node.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,17 +26,17 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart.chart" -}}
+{{- define "node.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "chart.labels" -}}
-helm.sh/chart: {{ include "chart.chart" . }}
-{{ include "chart.selectorLabels" . }}
-{{ include "chart.serviceLabels" . }}
+{{- define "node.labels" -}}
+helm.sh/chart: {{ include "node.chart" . }}
+{{ include "node.selectorLabels" . }}
+{{ include "node.serviceLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -49,15 +49,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+{{- define "node.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "node.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Service labels
 */}}
-{{- define "chart.serviceLabels" -}}
+{{- define "node.serviceLabels" -}}
 chain: {{ .Values.node.chain }}
 release: {{ .Release.Name }}
 role: {{ .Values.node.role }}
@@ -66,9 +66,9 @@ role: {{ .Values.node.role }}
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "chart.serviceAccountName" -}}
+{{- define "node.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "node.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/node/templates/customNodeKeySecret.yaml
+++ b/charts/node/templates/customNodeKeySecret.yaml
@@ -1,4 +1,4 @@
-{{ $fullname :=  include "chart.fullname" . }}
+{{ $fullname :=  include "node.fullname" . }}
 {{ if .Values.node.persistGeneratedNodeKey }}
 {{ else if .Values.node.customNodeKey }}
 apiVersion: v1

--- a/charts/node/templates/ingress.yaml
+++ b/charts/node/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-  {{- $fullName := include "chart.fullname" . -}}
+  {{- $fullName := include "node.fullname" . -}}
   {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
   {{- else if semverCompare ">=1.14-0 <1.19.0" .Capabilities.KubeVersion.GitVersion -}}
@@ -11,7 +11,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-  {{- include "chart.labels" . | nindent 4 }}
+  {{- include "node.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/charts/node/templates/keys.yaml
+++ b/charts/node/templates/keys.yaml
@@ -1,4 +1,4 @@
-{{ $fullname :=  include "chart.fullname" . }}
+{{ $fullname :=  include "node.fullname" . }}
 {{- range $keys := .Values.node.keys }}
 ---
 apiVersion: v1

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -1,12 +1,12 @@
-{{ $fullname :=  include "chart.fullname" . }}
-{{ $selectorLabels :=  include "chart.selectorLabels" .  }}
-{{ $serviceLabels :=  include "chart.serviceLabels" .  }}
+{{ $fullname :=  include "node.fullname" . }}
+{{ $selectorLabels :=  include "node.selectorLabels" .  }}
+{{ $serviceLabels :=  include "node.serviceLabels" .  }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullname }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "node.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/node/templates/serviceAccount.yaml
+++ b/charts/node/templates/serviceAccount.yaml
@@ -1,11 +1,11 @@
-{{ $serviceAccountName :=  include "chart.serviceAccountName" . }}
+{{ $serviceAccountName :=  include "node.serviceAccountName" . }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $serviceAccountName }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "node.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -21,7 +21,7 @@ rules:
     resources: ["services"]
     verbs: ["get", "list"]
 ---
-# Allow the {{ include "chart.serviceAccountName" . }}-service-port-retriever service account to read services in the {{ .Release.Namespace }} namespace
+# Allow the {{ include "node.serviceAccountName" . }}-service-port-retriever service account to read services in the {{ .Release.Namespace }} namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/node/templates/serviceMonitor.yaml
+++ b/charts/node/templates/serviceMonitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.node.serviceMonitor.enabled }}
-{{ $fullname :=  include "chart.fullname" . }}
-{{ $serviceLabels :=  include "chart.serviceLabels" .  }}
+{{ $fullname :=  include "node.fullname" . }}
+{{ $serviceLabels :=  include "node.serviceLabels" .  }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,7 +11,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   {{- end }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "node.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -1,13 +1,13 @@
-{{ $fullname :=  include "chart.fullname" . }}
-{{ $selectorLabels :=  include "chart.selectorLabels" . }}
-{{ $serviceLabels :=  include "chart.serviceLabels" .  }}
-{{ $serviceAccountName :=  include "chart.serviceAccountName" . }}
+{{ $fullname :=  include "node.fullname" . }}
+{{ $selectorLabels :=  include "node.selectorLabels" . }}
+{{ $serviceLabels :=  include "node.serviceLabels" .  }}
+{{ $serviceAccountName :=  include "node.serviceAccountName" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ $fullname }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "node.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -22,7 +22,7 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-      {{- include "chart.labels" . | nindent 8 }}
+      {{- include "node.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
As mentioned in #47 

As this breaks backward compatibility for anyone already using this charts helper templates in a parent chart I've bumped the major version.