### PR TITLE
Add default statefulset/pod labels 'chain' and 'role'

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "0.0.1"

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -41,6 +41,8 @@ helm.sh/chart: {{ include "node.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+chain: {{ .Values.node.chain }}
+role: {{ .Values.node.role }}
 {{- with .Values.extraLabels }}
 {{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
This is fully backward compatible even if the labels were already set manually on the chart as such it is only a fix upgrade.