### PR TITLE
[node] fix serviceaccount

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "0.0.1"

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -142,3 +142,4 @@ node:
 | `jaegerAgent.collector.url`        | The URL which jaeger agent sends data                                                                  | `nil`               |
 | `jaegerAgent.collector.port   `    | The port which jaeger agent sends data                                                                 | `14250`             |    
 | `extraContainers   `               | Sidecar containers to add to the node                                                                  | `[]`                |   
+| `serviceAccount`                   | ServiceAccount used in init containers                                                                 | `{create: true, createRoleBinding: true,  annotations: {}}` |

--- a/charts/node/templates/serviceAccount.yaml
+++ b/charts/node/templates/serviceAccount.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- end }}
 {{- end }}
 ---
+{{- if .Values.serviceAccount.createRoleBinding -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -34,3 +35,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ $serviceAccountName }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -256,7 +256,7 @@ spec:
               --scheme {{ .scheme }} \
               {{- if .extraDerivation }}
               --suri "$(cat /vault/secrets/{{ .name }}){{ .extraDerivation }}" \
-              {{ else }}
+              {{- else }}
               --suri "/vault/secrets/{{ .name }}" \
               {{- end }}
               && echo "Inserted key {{ .name }} (type={{ .type }}, scheme={{ .scheme }}) into Keystore" \

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -26,6 +26,8 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Specifies whether a RoleBinding should be created for service account
+  createRoleBinding: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
This PR fixes issue when you have multiple releases with the same serviceAccount, and can not create  `RoleBinding`
```
Error: UPGRADE FAILED: rendered manifests contain a resource that already exists. Unable to continue with update: Role "versi-parachains-service-reader" in namespace "versi" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "versi-tick-extra-501-a": current value is "versi-moonbase-bootnode"
```