### PR TITLE
Set extra labels on both pods and services

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: "0.0.1"

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -52,9 +52,6 @@ pruning: archive
 unsafe-pruning: false
 {{- end }}
 {{- end }}
-{{- with .Values.extraLabels }}
-{{ toYaml . }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -72,6 +69,9 @@ Service labels
 chain: {{ .Values.node.chain }}
 release: {{ .Release.Name }}
 role: {{ .Values.node.role }}
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -30,7 +30,7 @@ metadata:
   name: {{ $fullname }}-{{ $i }}
   labels:
     {{- $serviceLabels | nindent 4 }}
-    instance: {{ $fullname }}-{{ $i }}
+    node: {{ $fullname }}-{{ $i }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -54,6 +54,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Add extra labels on pods and services
 #extraLabels:
 #  type: rpc
 


### PR DESCRIPTION
To be taken into account by the `serviceMonitor` targetLabels, labels need to be on the created Service.