### PR TITLE
Fix scrape interval

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: "0.0.1"

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -129,8 +129,8 @@ node:
   serviceMonitor:
     enabled: false
     #namespace: monitoring
-    interval: 1m
-    scrapeTimeout: 30s
+    interval: 30s
+    scrapeTimeout: 10s
     targetLabels:
       - node
     relabelings: []


### PR DESCRIPTION
Recently we discovered that some Grafana dashboards do not work with nodes deployed in Kubernetes. The reason was magic variable `$__rate_interval` used in [dashboards](https://github.com/paritytech/substrate/blob/master/scripts/ci/monitoring/grafana-dashboards/substrate-service-tasks.json#L186) . `$__rate_interval`  depends on the [default scrape interval for Grafana data source](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/). Helm scrape interval should be same or close to the default scrape interval. 

## Changes 

1. Set scrape interval to the same value as in [prometheus stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L2127)
2. Bump chart version 