### PR TITLE
Set node version label to the image tag

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 1.5.3
-appVersion: "0.0.1"
+version: 1.5.4

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -37,9 +37,7 @@ Common labels
 helm.sh/chart: {{ include "node.chart" . }}
 {{ include "node.selectorLabels" . }}
 {{ include "node.serviceLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 chain: {{ .Values.node.chain }}
 role: {{ .Values.node.role }}


### PR DESCRIPTION
It is more useful to set the version to the image tag rather than to the hardcoded and unused `appVersion: "0.0.1"` variable.