### PR TITLE
Add substrate-faucet chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Parity's [Kubernetes Helm](https://helm.sh/) charts collection.
 - [Common](charts/common/README.md): a generic helm chart for kubernetes
 - [Node](charts/node/README.md): deploy Substrate/Polkadot nodes
 - [Substrate telemetry](charts/substrate-telemetry/README.md): deploy Substrate Telemetry for the nodes
+- [Substrate faucet](charts/substrate-faucet/README.md): deploy Substrate Faucet
 - [Introspector](charts/introspector/README.md): deploy introspector for the nodes

--- a/charts/substrate-faucet/.helmignore
+++ b/charts/substrate-faucet/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: substrate-faucet
+description: A Helm chart to deploy substrate-faucet
+type: application
+version: 1.0.0

--- a/charts/substrate-faucet/README.md
+++ b/charts/substrate-faucet/README.md
@@ -1,0 +1,53 @@
+# Substrate faucet helm chart
+
+The helm chart installs the [Substrate faucet](https://github.com/paritytech/substrate-matrix-faucet), a generic faucet for Substrate based chains.
+
+## Installing the chart
+
+To deploy a Westend faucet:
+```console
+helm repo add parity https://paritytech.github.io/helm-charts/
+helm install substrate-faucet parity/substrate-faucet \
+    --set node.chain="westend" \
+    --set server.secret.SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC="//Alice" \
+    --set server.config.SMF_BACKEND_RPC_ENDPOINT="https://westend-rpc.polkadot.io/" \
+    --set server.config.SMF_BACKEND_INJECTED_TYPES='{}' \
+    --set server.config.SMF_BACKEND_PORT=5555 \
+    --set bot.secret.SMF_BOT_MATRIX_ACCESS_TOKEN="******" \
+    --set bot.config.SMF_BOT_MATRIX_SERVER="https://matrix.org" \
+    --set bot.config.SMF_BOT_MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org" \
+    --set bot.config.SMF_BOT_NETWORK_UNIT="WND" \
+    --set bot.config.SMF_BOT_DRIP_AMOUNT="0.1"
+```
+
+## Parameters
+
+### Common parameters
+
+| Parameter            | Description                                | Default                        |
+|----------------------|--------------------------------------------|--------------------------------|
+| `imagePullSecrets`   | Labels to add to all deployed objects      | `[]`                           |
+| `nameOverride`       | String to partially override node.fullname | `nil`                          |
+| `fullnameOverride`   | String to fully override node.fullname     | `nil`                          |
+| `podSecurityContext` | Specify the pod security settings          | `{}`                           |  
+| `resources`          | Resources to set on pods                   | `{}`                           |  
+| `nodeSelector`       | Node labels for pod assignment             | `{}`                           |  
+| `tolerations`        | Tolerations for pod assignment             | `[]`                           |  
+| `affinity`           | Affinity for pod assignment                | `{}`                           |  
+
+### Substrate-faucet parameters
+
+| Parameter                 | Description                                                                  | Default     |
+|---------------------------|------------------------------------------------------------------------------|-------------|
+| `chain.name`              | Chain name                                                                   | `substrate` |
+| `replicaCount`            | Number of replicas for the bot and server pods (recommended to keep it at 1) | `1`         |
+| `server.image.repository` | Server image repository                                                      | `9615`      |
+| `server.image.tag`        | Server image tag                                                             | `9615`      |
+| `server.image.pullPolicy` | Server image pull policy                                                     | `9615`      |
+| `server.secret`           | Server secret environment variable map                                       | `{}`        |
+| `server.config`           | Server config environment variable map                                       | `{}`        |
+| `bot.image.repository`    | Bot image repository                                                         | `9615`      |
+| `bot.image.tag`           | Bot image tag                                                                | `9615`      |
+| `bot.image.pullPolicy`    | Bot image pull policy                                                        | `9615`      |
+| `bot.secret`              | Bot secret environment variable map                                          | `9615`      |
+| `bot.config`              | Bot config environment variable map                                          | `9615`      |

--- a/charts/substrate-faucet/templates/_helpers.tpl
+++ b/charts/substrate-faucet/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "faucet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "faucet.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "faucet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "faucet.labels" -}}
+helm.sh/chart: {{ include "faucet.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "faucet.botLabels" -}}
+{{ include "faucet.labels" . }}
+{{ include "faucet.botSelectorLabels" . }}
+{{- end -}}
+{{- define "faucet.serverLabels" -}}
+{{ include "faucet.labels" . }}
+{{ include "faucet.serverSelectorLabels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "faucet.botSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "faucet.name" . }}-bot
+app.kubernetes.io/instance: {{ .Release.Name }}-bot
+{{- end -}}
+{{- define "faucet.serverSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "faucet.name" . }}-server
+app.kubernetes.io/instance: {{ .Release.Name }}-server
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "faucet.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "faucet.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/substrate-faucet/templates/_helpers.tpl
+++ b/charts/substrate-faucet/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "faucet.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/substrate-faucet/templates/bot-configmap.yaml
+++ b/charts/substrate-faucet/templates/bot-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-bot-config
+data:
+  {{- range $key, $val := .Values.bot.config }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/charts/substrate-faucet/templates/bot-deployment.yaml
+++ b/charts/substrate-faucet/templates/bot-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-bot
+  labels:
+    {{- include "faucet.botLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "faucet.botSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "faucet.botSelectorLabels" . | nindent 8 }}
+      annotations:
+        configmap/checksum: {{ include (print $.Template.BasePath "/bot-configmap.yaml") . | sha256sum }}
+        secret/checksum: {{ include (print $.Template.BasePath "/bot-secret.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "faucet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: faucet-bot
+          image: "{{ .Values.bot.image.repository }}:{{ .Values.bot.image.tag }}"
+          imagePullPolicy: {{ .Values.bot.image.pullPolicy }}
+          env:
+          {{- range $key, $val := .Values.bot.secret }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  key: {{ $key }}
+                  name: {{ $.Release.Name }}-bot-secret
+          {{- end }}
+          {{- range $key, $val := .Values.bot.config }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ $key }}
+                  name: {{ $.Release.Name }}-bot-config
+          {{- end }}
+            - name: SMF_BOT_BACKEND_URL
+              value: "http://{{ .Release.Name }}-server:{{ .Values.server.config.SMF_BACKEND_PORT }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/substrate-faucet/templates/bot-secret.yaml
+++ b/charts/substrate-faucet/templates/bot-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-bot-secret
+type: Opaque
+data:
+  {{- range $key, $val := .Values.bot.secret }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/charts/substrate-faucet/templates/server-configmap.yaml
+++ b/charts/substrate-faucet/templates/server-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-server-config
+data:
+  {{- range $key, $val := .Values.server.config }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/charts/substrate-faucet/templates/server-deployment.yaml
+++ b/charts/substrate-faucet/templates/server-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-server
+  labels:
+    {{- include "faucet.serverLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "faucet.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "faucet.serverSelectorLabels" . | nindent 8 }}
+      annotations:
+        configmap/checksum: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
+        secret/checksum: {{ include (print $.Template.BasePath "/server-secret.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "faucet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: faucet-server
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          env:
+          {{- range $key, $val := .Values.server.secret }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  key: {{ $key }}
+                  name: {{ $.Release.Name }}-server-secret
+          {{- end }}
+          {{- range $key, $val := .Values.server.config }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  key: {{ $key }}
+                  name: {{ $.Release.Name }}-server-config
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 5555
+            failureThreshold: 0
+            periodSeconds: 10
+            initialDelaySeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5555
+            failureThreshold: 0
+            periodSeconds: 30
+            initialDelaySeconds: 60
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/substrate-faucet/templates/server-secret.yaml
+++ b/charts/substrate-faucet/templates/server-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-server-secret
+type: Opaque
+data:
+  {{- range $key, $val := .Values.server.secret }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}

--- a/charts/substrate-faucet/templates/service.yaml
+++ b/charts/substrate-faucet/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-server
+  labels:
+    {{- include "faucet.serverLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.server.config.SMF_BACKEND_PORT }}
+      name: metrics
+      protocol: TCP
+  selector:
+    {{- include "faucet.serverSelectorLabels" . | nindent 8 }}
+

--- a/charts/substrate-faucet/templates/serviceaccount.yaml
+++ b/charts/substrate-faucet/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "faucet.serviceAccountName" . }}
+  labels:
+{{ include "faucet.labels" . | nindent 4 }}
+{{- end -}}

--- a/charts/substrate-faucet/templates/servicemonitor.yaml
+++ b/charts/substrate-faucet/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-bot
+spec:
+  selector:
+    matchLabels:
+    {{- include "faucet.botSelectorLabels" . | nindent 8 }}
+  endpoints:
+    - port: metrics
+      interval: 15s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-server
+spec:
+  selector:
+    matchLabels:
+    {{- include "faucet.serverSelectorLabels" . | nindent 8 }}
+  endpoints:
+    - port: metrics
+      interval: 15s

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -1,0 +1,72 @@
+# Default values for faucetbot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+chain:
+  name: substrate
+
+replicaCount: 1
+
+server:
+  image:
+    repository: paritytech/faucet-server
+    tag: latest
+    pullPolicy: Always
+
+  secret:
+    SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC: "this is a fake mnemonic"
+
+  config:
+    SMF_BACKEND_RPC_ENDPOINT: "https://example.com/"
+    SMF_BACKEND_NETWORK_DECIMALS: 12
+    SMF_BACKEND_INJECTED_TYPES: '{}'
+    SMF_BACKEND_PORT: 5555
+
+bot:
+  image:
+    repository: paritytech/faucet-bot
+    tag: latest
+    pullPolicy: Always
+
+  secret:
+    # your bot access token here is how to find it https://t2bot.io/docs/access_tokens/
+    SMF_BOT_MATRIX_ACCESS_TOKEN: "ThisIsNotARealAccessToken"
+
+  config:
+    SMF_BOT_MATRIX_SERVER: "https://matrix.org"
+    SMF_BOT_MATRIX_BOT_USER_ID: "@test_bot_faucet:matrix.org"
+    SMF_BOT_DRIP_AMOUNT: 10
+    SMF_BOT_NETWORK_DECIMALS: 12
+    SMF_BOT_NETWORK_UNIT: "UNIT"
+    SMF_BOT_FAUCET_IGNORE_LIST: ''
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: westend
+
+podSecurityContext: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -40,6 +40,8 @@ bot:
     SMF_BOT_NETWORK_UNIT: "UNIT"
     SMF_BOT_FAUCET_IGNORE_LIST: ''
 
+extraLabels: []
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This is a revamped version of the chart present in [paritytech/substrate-matrix-faucet//kubernetes/faucetbot](https://github.com/paritytech/substrate-matrix-faucet/tree/de585c3/kubernetes/faucetbot).

The main addition is the separation of the bot and server components in two separate deployments and it also supports correctly rolling out deployment upgrades when the configmaps/secrets are modified.
