### PR TITLE
Avoid using double the amount of space when downloading a blockstore

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.0.0
+version: 2.1.0

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -13,12 +13,12 @@ This will deploy a single Polkadot node with the default configuration.
 
 Polkadot:
 ```console
-helm install polkadot-node parity/node --set node.chainDataSnapshotUrl=https://dot-rocksdb.polkashots.io/snapshot --set node.chainDataSnapshotFormat=7z
+helm install polkadot-node parity/node --set node.chainDataSnapshotUrl=https://dot-rocksdb.polkashots.io/snapshot --set node.chainDataSnapshotFormat=lz4
 ```
 
 Kusama:
 ```console
-helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm-rocksdb.polkashots.io/snapshot --set node.chainDataSnapshotFormat=7z --set node.chainPath=ksmcc3
+helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm-rocksdb.polkashots.io/snapshot --set node.chainDataSnapshotFormat=lz4 --set node.chainPath=ksmcc3
 ```
 ⚠️ For some chains where the local directory name is different from the chain ID, `node.chainPath` needs to be set to a custom value.
 
@@ -86,7 +86,7 @@ node:
 | `node.replica`                                                            | Number of replica in the node StatefulSet                                                                                                                                                                                                            | `1`                                                                 |
 | `node.role`                                                               | Set the role of the node: `full`, `authority`/`validator`, `collator` or `light`                                                                                                                                                                     | `full`                                                              |
 | `node.chainDataSnapshotUrl`                                               | Download and load chain data from a snapshot archive http URL                                                                                                                                                                                        | ``                                                                  |
-| `node.chainDataSnapshotFormat`                                            | The snapshot archive format (`tar` or `7z`)                                                                                                                                                                                                          | `tar`                                                               |
+| `node.chainDataSnapshotFormat`                                            | The snapshot archive format (`tar` or `lz4`)                                                                                                                                                                                                          | `tar`                                                               |
 | `node.chainDataGcsBucketUrl`                                              | Sync chain data files from a GCS bucket (eg. `gs://bucket-name/folder-name`)                                                                                                                                                                         | ``                                                                  |
 | `node.chainPath`                                                          | Path at which the chain database files are located (`/data/chains/${CHAIN_PATH}`)                                                                                                                                                                    | `nil` (if undefined, fallbacks to the value in `node.chain`)        |
 | `node.chainDataKubernetesVolumeSnapshot`                                  | Initialize the chain data volume from a Kubernetes VolumeSnapshot                                                                                                                                                                                    | ``                                                                  |
@@ -95,7 +95,7 @@ node:
 | `node.collator.isParachain`                                               | If true, configure the node as a parachain (set the relay-chain flags after `--`)                                                                                                                                                                    | `nil`                                                               |
 | `node.collator.relayChainCustomChainspecUrl`                              | Download and use a custom relay-chain chainspec file from a URL                                                                                                                                                                                      | `nil`                                                               |
 | `node.collator.relayChainDataSnapshotUrl`                                 | Download and load relay-chain data from a snapshot archive http URL                                                                                                                                                                                  | `nil`                                                               |
-| `node.collator.relayChainDataSnapshotFormat`                              | The relay-chain snapshot archive format (`tar` or `7z`)                                                                                                                                                                                              | `nil`                                                               |
+| `node.collator.relayChainDataSnapshotFormat`                              | The relay-chain snapshot archive format (`tar` or `lz4`)                                                                                                                                                                                              | `nil`                                                               |
 | `node.collator.relayChainPath`                                            | Path at which the chain database files are located (`/data/polkadot/chains/${RELAY_CHAIN_PATH}`)                                                                                                                                                     | `nil`                                                               |
 | `node.collator.relayChainDataKubernetesVolumeSnapshot`                    | Initialize the relay-chain data volume from a Kubernetes VolumeSnapshot                                                                                                                                                                              | `nil`                                                               |
 | `node.collator.relayChainDataGcsBucketUrl`                                | Sync relay-chain data files from a GCS bucket (eg. `gs://bucket-name/folder-name`)                                                                                                                                                                   | `nil`                                                               |
@@ -144,7 +144,7 @@ node:
 | `image.repository`                 | Node image name                                                                                        | `parity/polkadot`   |
 | `image.tag`                        | Node image tag                                                                                         | `latest`            |
 | `image.pullPolicy`                 | Node image pull policy                                                                                 | `Always`            |
-| `initContainer.image.repository`   | Download-chain-snapshot init container image name                                                      | `crazymax/7zip`     |
+| `initContainer.image.repository`   | Download-chain-snapshot init container image name                                                      | `alpine`     |
 | `initContainer.image.tag`          | Download-chain-snapshot init container image tag                                                       | `latest`            |
 | `googleCloudSdk.image.repository`  | Sync-chain-gcs init container image name                                                               | `google/cloud-sdk`  |
 | `googleCloudSdk.image.tag`         | Sync-chain-gcs init container image tag                                                                | `slim`              |
@@ -160,6 +160,6 @@ node:
 | `jaegerAgent.ports.binaryPort`     | Port to use for jaeger.thrift over binary thrift protocol                                              | `6832`              |
 | `jaegerAgent.ports.samplingPort`   | Port for HTTP sampling strategies                                                                      | `5778`              |
 | `jaegerAgent.collector.url`        | The URL which jaeger agent sends data                                                                  | `nil`               |
-| `jaegerAgent.collector.port   `    | The port which jaeger agent sends data                                                                 | `14250`             |    
-| `extraContainers   `               | Sidecar containers to add to the node                                                                  | `[]`                |   
+| `jaegerAgent.collector.port   `    | The port which jaeger agent sends data                                                                 | `14250`             |
+| `extraContainers   `               | Sidecar containers to add to the node                                                                  | `[]`                |
 | `serviceAccount`                   | ServiceAccount used in init containers                                                                 | `{create: true, createRoleBinding: true,  annotations: {}}` |

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -72,23 +72,19 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
+              apk add --no-cache curl lz4
               if [ -d "/data/chains/${CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping chain snapshot download"
               else
                 echo "Downloading chain snapshot"
                 SNAPSHOT_URL="{{ .Values.node.chainDataSnapshotUrl }}"
-                wget -O /data/snapshot ${SNAPSHOT_URL}
-                if [ ! -f /data/snapshot ]; then
-                  echo "Failed to download chain snapshot"
-                  exit 1
-                fi
-                mkdir -p /data/chains/${CHAIN_PATH}/
-                if [ "${SNAPSHOT_FORMAT}" == "7z" ]; then
-                  7z x /data/snapshot -o/data/chains/${CHAIN_PATH}/
+                mkdir -p /data/chains/${CHAIN_PATH}/db/full
+                if [ "${SNAPSHOT_FORMAT}" == "lz4" ]; then
+                  curl -o - -L ${SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${CHAIN_PATH}/db/full/
                 else
-                  tar xvf /data/snapshot --directory=/data/chains/${CHAIN_PATH}/db/full/
+                  curl -o - -L ${SNAPSHOT_URL} | tar -x -C /data/chains/${CHAIN_PATH}/db/full/
                 fi
-                rm /data/snapshot
               fi
           env:
             - name: CHAIN_PATH
@@ -106,23 +102,19 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
+              apk add --no-cache curl lz4
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping relay-chain snapshot download"
               else
                 echo "Downloading relay-chain snapshot"
                 RELAY_SNAPSHOT_URL="{{ .Values.node.collator.relayChainDataSnapshotUrl }}"
-                wget -O /data/relay-snapshot ${RELAY_SNAPSHOT_URL}
-                if [ ! -f /data/relay-snapshot ]; then
-                  echo "Failed to download relay-chain snapshot"
-                  exit 1
-                fi
-                mkdir -p /data/relay/chains/${RELAY_CHAIN_PATH}/
-                if [ "${RELAY_SNAPSHOT_FORMAT}" == "7z" ]; then
-                  7z x /data/relay-snapshot -o/data/relay/chains/${RELAY_CHAIN_PATH}/
+                mkdir -p /data/relay/chains/${RELAY_CHAIN_PATH}/db/full
+                if [ "${RELAY_SNAPSHOT_FORMAT}" == "lz4" ]; then
+                  curl -o - -L ${RELAY_SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/db/full/
                 else
-                  tar xvf /data/relay-snapshot --directory=/data/relay/chains/${RELAY_CHAIN_PATH}/db/full/
+                  curl -o - -L ${RELAY_SNAPSHOT_URL} | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/db/full/
                 fi
-                rm /data/relay-snapshot
               fi
           env:
             - name: RELAY_SNAPSHOT_FORMAT
@@ -140,6 +132,7 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -174,9 +167,10 @@ spec:
           args:
             - -c
             - |
-               {{- if .Values.googleCloudSdk.serviceAccountKey }}
+              set -eu -o pipefail
+              {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
-               {{- end }}
+              {{- end }}
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/db" ]; then
                 echo "Relay-chain database directory already exists, skipping GCS sync"
               else
@@ -208,11 +202,13 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
+              apk add --no-cache curl
               {{- if .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.customChainspecPath }} ]; then
               {{- end }}
-                wget -O {{ .Values.node.customChainspecPath }} {{ .Values.node.customChainspecUrl }}
+                curl -L -o {{ .Values.node.customChainspecPath }} {{ .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               fi
               {{- end }}
@@ -221,7 +217,7 @@ spec:
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.relayChainCustomChainspecPath }} ]; then
               {{- end }}
-                wget -O {{ .Values.node.relayChainCustomChainspecPath }} {{ .Values.node.collator.relayChainCustomChainspecUrl }}
+                curl -L -o {{ .Values.node.relayChainCustomChainspecPath }} {{ .Values.node.collator.relayChainCustomChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               fi
               {{- end }}
@@ -237,6 +233,7 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
               {{- range $keys := .Values.node.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -263,6 +260,7 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
               {{- range $keys := .Values.node.vault.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -290,6 +288,7 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
@@ -316,6 +315,7 @@ spec:
           args:
             - -c
             - |
+              set -eu -o pipefail
               POD_INDEX="${HOSTNAME##*-}"
               {{- if or $.Values.node.perNodeServices.relayP2pService.enabled $.Values.node.perNodeServices.paraP2pService.enabled }}
               {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -73,7 +73,6 @@ spec:
             - -c
             - |
               set -eu -o pipefail
-              apk add --no-cache wget lz4
               if [ -d "/data/chains/${CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping chain snapshot download"
               else
@@ -94,8 +93,6 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: chain-data
-          securityContext:
-            runAsUser: 0
         {{- end }}
         {{- if .Values.node.collator.relayChainDataSnapshotUrl }}
         - name: download-relay-chain-snapshot
@@ -105,7 +102,6 @@ spec:
             - -c
             - |
               set -eu -o pipefail
-              apk add --no-cache wget lz4
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping relay-chain snapshot download"
               else
@@ -126,8 +122,6 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: chain-data
-          securityContext:
-            runAsUser: 0
         {{- end }}
         {{- if .Values.node.chainDataGcsBucketUrl }}
         - name: sync-chain-gcs

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             - -c
             - |
               set -eu -o pipefail
-              apk add --no-cache curl lz4
+              apk add --no-cache wget lz4
               if [ -d "/data/chains/${CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping chain snapshot download"
               else
@@ -81,9 +81,9 @@ spec:
                 SNAPSHOT_URL="{{ .Values.node.chainDataSnapshotUrl }}"
                 mkdir -p /data/chains/${CHAIN_PATH}/db/full
                 if [ "${SNAPSHOT_FORMAT}" == "lz4" ]; then
-                  curl -o - -L ${SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${CHAIN_PATH}/db/full/
+                  wget -O - ${SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${CHAIN_PATH}/
                 else
-                  curl -o - -L ${SNAPSHOT_URL} | tar -x -C /data/chains/${CHAIN_PATH}/db/full/
+                  wget -O - ${SNAPSHOT_URL} | tar -x -C /data/chains/${CHAIN_PATH}/db/full/
                 fi
               fi
           env:
@@ -94,6 +94,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: chain-data
+          securityContext:
+            runAsUser: 0
         {{- end }}
         {{- if .Values.node.collator.relayChainDataSnapshotUrl }}
         - name: download-relay-chain-snapshot
@@ -103,7 +105,7 @@ spec:
             - -c
             - |
               set -eu -o pipefail
-              apk add --no-cache curl lz4
+              apk add --no-cache wget lz4
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/db" ]; then
                 echo "Database directory already exists, skipping relay-chain snapshot download"
               else
@@ -111,9 +113,9 @@ spec:
                 RELAY_SNAPSHOT_URL="{{ .Values.node.collator.relayChainDataSnapshotUrl }}"
                 mkdir -p /data/relay/chains/${RELAY_CHAIN_PATH}/db/full
                 if [ "${RELAY_SNAPSHOT_FORMAT}" == "lz4" ]; then
-                  curl -o - -L ${RELAY_SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/db/full/
+                  wget -O - ${RELAY_SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/
                 else
-                  curl -o - -L ${RELAY_SNAPSHOT_URL} | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/db/full/
+                  wget -O - ${RELAY_SNAPSHOT_URL} | tar -x -C /data/chains/${RELAY_CHAIN_PATH}/db/full/
                 fi
               fi
           env:
@@ -124,6 +126,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: chain-data
+          securityContext:
+            runAsUser: 0
         {{- end }}
         {{- if .Values.node.chainDataGcsBucketUrl }}
         - name: sync-chain-gcs
@@ -132,7 +136,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -167,7 +171,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -203,12 +207,12 @@ spec:
             - -c
             - |
               set -eu -o pipefail
-              apk add --no-cache curl
+              apk add --no-cache wget
               {{- if .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.customChainspecPath }} ]; then
               {{- end }}
-                curl -L -o {{ .Values.node.customChainspecPath }} {{ .Values.node.customChainspecUrl }}
+                wget -O {{ .Values.node.customChainspecPath }} {{ .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               fi
               {{- end }}
@@ -217,7 +221,7 @@ spec:
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.relayChainCustomChainspecPath }} ]; then
               {{- end }}
-                curl -L -o {{ .Values.node.relayChainCustomChainspecPath }} {{ .Values.node.collator.relayChainCustomChainspecUrl }}
+                wget -O {{ .Values.node.relayChainCustomChainspecPath }} {{ .Values.node.collator.relayChainCustomChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               fi
               {{- end }}
@@ -225,6 +229,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: chain-data
+          securityContext:
+            runAsUser: 0
         {{- end }}
         {{- if .Values.node.keys }}
         - name: inject-keys
@@ -233,7 +239,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               {{- range $keys := .Values.node.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -260,7 +266,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               {{- range $keys := .Values.node.vault.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -288,7 +294,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
@@ -315,7 +321,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eu
               POD_INDEX="${HOSTNAME##*-}"
               {{- if or $.Values.node.perNodeServices.relayP2pService.enabled $.Values.node.perNodeServices.paraP2pService.enabled }}
               {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -5,7 +5,7 @@ image:
 
 initContainer:
   image:
-    repository: crazymax/7zip
+    repository: alpine
     tag: latest
 
 kubectl:
@@ -70,7 +70,7 @@ node:
   customChainspecPath: "/data/chainspec.json"
   forceDownloadChainspec: false
   #chainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
-  #chainDataSnapshotFormat: 7z
+  #chainDataSnapshotFormat: lz4
   #chainPath: ""
   #chainDataKubernetesVolumeSnapshot: ""
   #chainDataGcsBucketUrl: ""
@@ -80,7 +80,7 @@ node:
   #  relayChainCustomChainspecUrl: ""
   relayChainCustomChainspecPath: "/data/relay_chain_chainspec.json"
   #  relayChainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
-  #  relayChainDataSnapshotFormat: 7z
+  #  relayChainDataSnapshotFormat: lz4
   #  relayChainPath: ""
   #  relayChainDataKubernetesVolumeSnapshot: ""
   #  relayChainDataGcsBucketUrl: ""

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -5,7 +5,7 @@ image:
 
 initContainer:
   image:
-    repository: alpine
+    repository: paritytech/lz4
     tag: latest
 
 kubectl:


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Previous implementation of init container for downloading a blockstore had been using double the amount of disk space. It first downloaded a compressed archive and then unpacked it to the target directory.
This PR fixes it by merging these two steps into one. We stream the compressed byte array produced by `wget` and pipe it further for extraction.

Other quality of life improvements:
- existing implementation for unpacking 7z archives was primarily in place to download snapshots from Polkashots.io. As they migrated from 7z to lz4 compression it no longer worked. I replaced `crazymax/7z` image with [`paritytech/lz4`](https://github.com/paritytech/scripts/pull/425) where `lz4` package is installed to support the new format.
- use `set -eu -pipefail` shell options as a safety net in case of errors in scripts. `-e` will exit immediately on error instead of continuing execution. `-u` will exit on undefined variables. `pipefail` will exit on errors in between the piped programs