### PR TITLE
Add service annotations

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.5.0
+version: 2.5.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullname }}
+{{- with .Values.node.serviceAnnotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   labels:
     {{- $serviceLabels | nindent 4 }}
 spec:

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -242,6 +242,8 @@ node:
     relabelings: []
     metricRelabelings: []
 
+  serviceAnnotations: {}
+
   ## Configuration of individual services of node
   ##
   perNodeServices:


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Add support for annotations in the main Service. I have a use-case to add annotations on a Service to pass GCP's [BackendConfiguration](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#create_service)