### PR TITLE
[Node] add `-x` to initContainers

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.6.1
+version: 2.6.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           args:
             - -c
             - |
-              set -eux -o pipefail
+              set -eu -o pipefail {{ if .Values.initContainer.debug }}-x{{ end }}
               if [ -d "/data/chains/${CHAIN_PATH}/{{ $databasePath }}" ]; then
                 echo "Database directory already exists, skipping chain snapshot download"
               else
@@ -102,7 +102,7 @@ spec:
           args:
             - -c
             - |
-              set -eux -o pipefail
+              set -eu -o pipefail {{ if .Values.initContainer.debug }}-x{{ end }}
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}" ]; then
                 echo "Database directory already exists, skipping relay-chain snapshot download"
               else
@@ -131,7 +131,7 @@ spec:
           args:
             - -c
             - |
-              set -eux
+              set -eu {{ if .Values.initContainer.debug }}-x{{ end }}
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -166,7 +166,7 @@ spec:
           args:
             - -c
             - |
-              set -eux
+              set -eu {{ if .Values.initContainer.debug }}-x{{ end }}
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -201,7 +201,7 @@ spec:
           args:
             - -c
             - |
-              set -eux -o pipefail
+              set -eu -o pipefail {{ if .Values.initContainer.debug }}-x{{ end }}
               {{- if .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.customChainspecPath }} ]; then
@@ -233,7 +233,7 @@ spec:
           args:
             - -c
             - |
-              set -eux
+              set -eu {{ if .Values.initContainer.debug }}-x{{ end }}
               {{- range $keys := .Values.node.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -260,7 +260,7 @@ spec:
           args:
             - -c
             - |
-              set -eu
+              set -eu {{ if .Values.initContainer.debug }}-x{{ end }}
               {{- range $keys := .Values.node.vault.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -288,7 +288,7 @@ spec:
           args:
             - -c
             - |
-              set -eux
+              set -eu {{ if .Values.initContainer.debug }}-x{{ end }}
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eux -o pipefail
               if [ -d "/data/chains/${CHAIN_PATH}/{{ $databasePath }}" ]; then
                 echo "Database directory already exists, skipping chain snapshot download"
               else
@@ -102,7 +102,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
+              set -eux -o pipefail
               if [ -d "/data/relay/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}" ]; then
                 echo "Database directory already exists, skipping relay-chain snapshot download"
               else
@@ -131,7 +131,7 @@ spec:
           args:
             - -c
             - |
-              set -eu
+              set -eux
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -166,7 +166,7 @@ spec:
           args:
             - -c
             - |
-              set -eu
+              set -eux
               {{- if .Values.googleCloudSdk.serviceAccountKey }}
               gcloud auth activate-service-account --key-file /tmp/service-account-key.json
               {{- end }}
@@ -201,8 +201,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail
-              apk add --no-cache wget
+              set -eux -o pipefail
               {{- if .Values.node.customChainspecUrl }}
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.customChainspecPath }} ]; then
@@ -234,7 +233,7 @@ spec:
           args:
             - -c
             - |
-              set -eu
+              set -eux
               {{- range $keys := .Values.node.keys }}
               {{ $.Values.node.command }} key insert --base-path /data \
               --chain {{ if $.Values.node.customChainspecUrl }}{{ $.Values.node.customChainspecPath }}{{ else }}${CHAIN}{{ end }} \
@@ -289,7 +288,7 @@ spec:
           args:
             - -c
             - |
-              set -eu
+              set -eux
               POD_INDEX="${HOSTNAME##*-}"
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -29,6 +29,10 @@ initContainer:
   image:
     repository: paritytech/lz4
     tag: latest
+  ## Add `-x` shell option to initContainers
+  ## Note: passwords and keys used in initContainers can appear in logs
+  ##
+  debug: false
 
 ## Image of kubectl to use for relay P2p service
 ##


### PR DESCRIPTION
1. We have `echo` to print debug messages in initContainers but sometimes it is not enough to understand which command failed, adding `-x` will fix it.

 
2. Removed `apk add --no-cache wget` since alpine container already has wget
