### PR TITLE
Fix missing Prometheus port

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.7.0
+version: 2.7.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
       name: http-rpc
     - port: 9944
       name: websocket-rpc
-    {{- if $.Values.node.serviceMonitor.enabled }}
+    {{- if and $.Values.node.serviceMonitor.enabled (not $.Values.node.perNodeServices.apiService.enabled) }}
     - port: {{ .Values.node.prometheus.port | int }}
       name: prometheus
     {{- end }}

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -25,6 +25,10 @@ spec:
       name: http-rpc
     - port: 9944
       name: websocket-rpc
+    {{- if $.Values.node.serviceMonitor.enabled }}
+    - port: {{ .Values.node.prometheus.port | int }}
+      name: prometheus
+    {{- end }}
 ---
 {{range $i := until (.Values.node.replicas | int) }}
 {{- if $.Values.node.perNodeServices.apiService.enabled }}

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -30,7 +30,7 @@ spec:
       name: prometheus
     {{- end }}
     {{- if $.Values.node.collator.relayChainPrometheus.enabled }}
-    - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort}}
+    - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort | int }}
       name: prom-relaychain
     {{- end }}
 ---
@@ -67,14 +67,14 @@ spec:
     {{- $selectorLabels | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
   ports:
-    - port: {{ $.Values.node.perNodeServices.apiService.httpPort }}
+    - port: {{ $.Values.node.perNodeServices.apiService.httpPort | int }}
       name: http-rpc
-    - port: {{ $.Values.node.perNodeServices.apiService.wsPort }}
+    - port: {{ $.Values.node.perNodeServices.apiService.wsPort | int }}
       name: websocket-rpc
-    - port: {{ $.Values.node.perNodeServices.apiService.prometheusPort }}
+    - port: {{ $.Values.node.perNodeServices.apiService.prometheusPort | int }}
       name: prometheus
     {{- if $.Values.node.collator.relayChainPrometheus.enabled }}
-    - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort}}
+    - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort | int }}
       name: prom-relaychain
     {{- end }}
 {{- end }}
@@ -109,7 +109,7 @@ spec:
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
   ports:
     - name: p2p
-      port: {{ $.Values.node.perNodeServices.relayP2pService.port }}
+      port: {{ $.Values.node.perNodeServices.relayP2pService.port | int }}
       targetPort: 30333
 {{- end }}
 ---
@@ -143,7 +143,7 @@ spec:
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
   ports:
     - name: p2p
-      port: {{ $.Values.node.perNodeServices.paraP2pService.port }}
+      port: {{ $.Values.node.perNodeServices.paraP2pService.port | int }}
       targetPort: 30334
 {{- end }}
 ---

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -29,6 +29,10 @@ spec:
     - port: {{ .Values.node.prometheus.port | int }}
       name: prometheus
     {{- end }}
+    {{- if $.Values.node.collator.relayChainPrometheus.enabled }}
+    - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort}}
+      name: prom-relaychain
+    {{- end }}
 ---
 {{range $i := until (.Values.node.replicas | int) }}
 {{- if $.Values.node.perNodeServices.apiService.enabled }}


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

A Service was missing a Prometheus port. It led to a ServiceMonitor referencing an undefined named port `prometheus` and, consequently, targets not being scraped.