### PR TITLE
[node] fix clusterIP

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.8.0
+version: 2.9.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -55,10 +55,10 @@ metadata:
 spec:
   {{- if eq $.Values.node.perNodeServices.apiService.type "ClusterIP" }}
   type: ClusterIP
+  clusterIP: None
   {{- else if eq $.Values.node.perNodeServices.apiService.type "NodePort" }}
   externalTrafficPolicy: {{ $.Values.node.perNodeServices.apiService.externalTrafficPolicy }}
   type: NodePort
-  clusterIP: None
   {{- else if eq $.Values.node.perNodeServices.apiService.type "LoadBalancer" }}
   externalTrafficPolicy: {{ $.Values.node.perNodeServices.apiService.externalTrafficPolicy }}
   type: LoadBalancer


### PR DESCRIPTION
I tried:
```
        node:
          perNodeServices:
            apiService:
              type: NodePort
```
And get error:
```
Error: UPGRADE FAILED: failed to create resource: Service "chart-name-node-0" is invalid: spec.clusterIPs[0]: Invalid value: "None": may not be set to 'None' for NodePort services
```
This look like a mistake in template.
