### PR TITLE
Update GCS sync settings

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.10.0
+version: 2.10.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -218,7 +218,7 @@ spec:
                   exit 1
                 fi
                 mkdir -p /data/relay/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}
-                gsutil -m -o "GSUtil:parallel_process_count=3" -o "GSUtil:parallel_thread_count=15" rsync -d -r ${BUCKET_URL}/${LATEST} /data/relay/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}/
+                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} rsync -d -r ${BUCKET_URL}/${LATEST} /data/relay/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}/
               fi
           env:
             - name: RELAY_CHAIN_PATH
@@ -455,7 +455,7 @@ spec:
             {{- if and .Values.node.collator.isParachain .Values.node.collator.relayChainPrometheus.enabled }}
             - containerPort: {{ .Values.node.collator.relayChainPrometheus.port }}
               name: prom-relaychain
-            {{- end }}    
+            {{- end }}
             - containerPort: 30333
               name: p2p
               protocol: TCP

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -47,7 +47,7 @@ googleCloudSdk:
   image:
     repository: google/cloud-sdk
     tag: slim # more lightweight than the full image and still contains gsutil
-  gsutilFlags: "-m -o 'GSUtil:parallel_process_count=8' -o 'GSUtil:parallel_thread_count=4'"
+  gsutilFlags: '-m -o "GSUtil:parallel_process_count=$(nproc --all)" -o "GSUtil:parallel_thread_count=2"'
   # serviceAccountKey: ""
 
 ## Reference to one or more secrets to be used when pulling images


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

- Update `gsutilFlags` flag to dynamically configure parallelism based on the number of available vCPUs. Reduce threads count as my tests shown better performance with 2 threads per core on SMT-enabled CPUs.
- Configure parachain sync container to also use `gsutilFlags` variable