### PR TITLE
Update HPA apiVersion to v2beta2

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.11.1
+version: 2.11.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/hpa.yaml
+++ b/charts/node/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{ $fullname :=  include "node.fullname" . }}
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $fullname }}


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Update HPA apiVersion to v2beta2 as v2 is not yet supported in 1.22.

I initially attempted to implement some smart `apiVersion` resolution as in https://github.com/bitnami/charts/blob/master/template/CHART_NAME/templates/hpa.yaml but it seems that Bitnami's implementation contains a bug. Specifically, if `apiVersion` is set to `v2beta2` an HPA object [definition with `target`](https://github.com/bitnami/charts/blob/master/template/CHART_NAME/templates/hpa.yaml#L29) must used. In contrast, `v2beta1` only supports legacy object definition using [`targetAverageUtilization`](https://github.com/bitnami/charts/blob/master/template/CHART_NAME/templates/hpa.yaml#L27) which is not handled in Bitnami's template.