### PR TITLE
Pre-create perNodeServices when HPA is enabled

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 2.11.3
+version: 2.11.4
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/hpa.yaml
+++ b/charts/node/templates/hpa.yaml
@@ -9,8 +9,8 @@ spec:
     apiVersion: apps/v1
     kind: StatefulSet
     name: {{ $fullname }}
-  minReplicas: {{ .Values.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | int }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | int }}
   metrics:
     {{- if .Values.autoscaling.targetMemory }}
     - type: Resource
@@ -18,7 +18,7 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemory }}
+          averageUtilization: {{ .Values.autoscaling.targetMemory | int }}
     {{- end }}
     {{- if .Values.autoscaling.targetCPU }}
     - type: Resource
@@ -26,7 +26,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPU }}
+          averageUtilization: {{ .Values.autoscaling.targetCPU | int }}
     {{- end }}
     {{- with .Values.autoscaling.additionalMetrics }}
     {{- toYaml . | nindent 4 }}

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
       name: prom-relaychain
     {{- end }}
 ---
-{{range $i := until (.Values.node.replicas | int) }}
+{{range $i := until (max .Values.autoscaling.maxReplicas .Values.node.replicas | int) }}
 {{- if $.Values.node.perNodeServices.apiService.enabled }}
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Closes: #124 

Generation of `perNodeServices` Services relied on the presence of `replicas` field. When HPA is enabled `replicas` remains constant while more replicas can still be created during scale up. Existing procedure for Service generation did not accommodate for it.
The fix now pre-creates Services based on the max(HPAMaxReplicas, Replicas)

cc: @dblane-digicatapult. Thanks for the suggestion. We really need to pull this fix quickly.