### PR TITLE
Fix chainspec download path

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 3.0.0
+version: 3.1.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -114,9 +114,9 @@ node:
 
   ## Node may require custom name for chainspec file.
   ## ref:  moonbeam https://github.com/PureStake/moonbeam/issues/1104#issuecomment-996787548
-  ## Note: path should start with /data/ since this folder mount in init container download-chainspec.
+  ## Note: path should start with /chain-data/ since this folder mount in init container download-chainspec.
   ##
-  customChainspecPath: "/data/chainspec.json"
+  customChainspecPath: "/chain-data/chainspec.json"
   # customChainspecUrl:
   forceDownloadChainspec: false
 


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Fix `customChainspecPath` as chain data was relocated to `/chain-data` in #136 