### PR TITLE
Use the wget -nc for runtime downloads

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 3.2.0
+version: 3.2.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -281,7 +281,7 @@ spec:
             - |
               set -eu -o pipefail {{ if .Values.initContainer.debug }}-x{{ end }}
               mkdir -p {{ .Values.node.wasmRuntimeOverridesPath }}
-              wget -P {{ .Values.node.wasmRuntimeOverridesPath }} {{ .Values.node.wasmRuntimeUrl }}
+              wget -P -nc {{ .Values.node.wasmRuntimeOverridesPath }} {{ .Values.node.wasmRuntimeUrl }}
           volumeMounts:
             - mountPath: /chain-data
               name: chain-data


### PR DESCRIPTION
Fixes runtime files being duplicated like this:
```
kusama_runtime-v9271.compact.compressed.wasm 
kusama_runtime-v9271.compact.compressed.wasm.1
```