### PR TITLE
[Node] Replace Kubectl Image in init-container

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 3.6.0
+version: 3.6.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -38,8 +38,8 @@ initContainer:
 ##
 kubectl:
   image:
-    repository: bitnami/kubectl
-    tag: latest
+    repository: paritytech/kubetools
+    tag: kubectl
 
 ## Used to sync chain from/to GCS bucket
 ##


### PR DESCRIPTION
With the recent changes in the bitnami/kubectl, it removes the package `curl` which breaks the retrieval of port. It's more beneficial to use our own image in case we need to add more packages and avoid having unexpected package removal.