### PR TITLE
Fix faucet bot version env variable

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/bot-deployment.yaml
+++ b/charts/substrate-faucet/templates/bot-deployment.yaml
@@ -47,9 +47,9 @@ spec:
           {{- end }}
             - name: SMF_BOT_BACKEND_URL
               value: "http://{{ .Release.Name }}-server:{{ .Values.server.config.SMF_BACKEND_PORT }}"
-            - name: SMF_BACKEND_DEPLOYED_REF
+            - name: SMF_BOT_DEPLOYED_REF
               value: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
-            - name: SMF_BACKEND_DEPLOYED_TIME
+            - name: SMF_BOT_DEPLOYED_TIME
               value: {{ now | date "2006-01-02T15:04:05" | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
The server env variable was copy-pasted on the bot config which was invalid. This PR sets the correct variable.