### PR TITLE
Fix faucet generated configmap/secret reference

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 1.2.1
+version: 1.2.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/bot-deployment.yaml
+++ b/charts/substrate-faucet/templates/bot-deployment.yaml
@@ -36,14 +36,14 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: {{ $key }}
-                  name: {{ $.Values.bot.existingSecret | default (printf "%s-bot-secret" $.Release.Namespace) }}
+                  name: {{ $.Values.bot.existingSecret | default (printf "%s-bot-secret" $.Release.Name) }}
           {{- end }}
           {{- range $key, $val := .Values.bot.config }}
             - name: {{ $key }}
               valueFrom:
                 configMapKeyRef:
                   key: {{ $key }}
-                  name: {{ $.Values.bot.existingConfigMap | default (printf "%s-bot-config" $.Release.Namespace) }}
+                  name: {{ $.Values.bot.existingConfigMap | default (printf "%s-bot-config" $.Release.Name) }}
           {{- end }}
             - name: SMF_BOT_BACKEND_URL
               value: "http://{{ .Release.Name }}-server:{{ .Values.server.config.SMF_BACKEND_PORT }}"

--- a/charts/substrate-faucet/templates/server-deployment.yaml
+++ b/charts/substrate-faucet/templates/server-deployment.yaml
@@ -36,14 +36,14 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: {{ $key }}
-                  name: {{ $.Values.server.existingSecret | default (printf "%s-server-secret" $.Release.Namespace) }}
+                  name: {{ $.Values.server.existingSecret | default (printf "%s-server-secret" $.Release.Name) }}
           {{- end }}
           {{- range $key, $val := .Values.server.config }}
             - name: {{ $key }}
               valueFrom:
                 configMapKeyRef:
                   key: {{ $key }}
-                  name: {{ $.Values.server.existingConfigMap | default (printf "%s-server-config" $.Release.Namespace) }}
+                  name: {{ $.Values.server.existingConfigMap | default (printf "%s-server-config" $.Release.Name) }}
           {{- end }}
             - name: SMF_BACKEND_DEPLOYED_REF
               value: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"


### PR DESCRIPTION
The secret configmap referred in the deployment should be: `${RELEASE-NAME}-|[server|bot]-[secret|configmap]` instead `${RELEASE-NAMESPACE-|[server|bot]-[secret|configmap]`release name.
The error was introduced in https://github.com/paritytech/helm-charts/pull/160 and untested on this setup until today.