### PR TITLE
Extend service selector labels

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.0.1
+version: 4.0.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -59,6 +59,7 @@ Selector labels
 {{- define "node.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "node.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: substrate-node
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Add `app.kubernetes.io/component` service selector label to narrow down the selection of Pods a service may become responsible for. It is useful when the chart is extended ad-hoc with other templates that spawn Pods that share same labels with the parent chart. Thus a service selects redundant Pods.