### PR TITLE
Update gsync command to sync faster

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.1.0
+version: 4.1.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -145,7 +145,7 @@ spec:
                 BUCKET_URL="{{ .Values.node.chainBackupGcsUrl }}/${HOSTNAME}"
                 NOW=$(date +"%Y%m%d-%H%M%S")
                 echo -e "\nStart gsutil backup\n"
-                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} rsync -d -r /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/ ${BUCKET_URL}/${NOW}
+                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} cp -r /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/ ${BUCKET_URL}/${NOW}
                 size=$(gsutil du -s ${BUCKET_URL}/${NOW} | awk '{ print $1 }' )
                 echo -e "size:
                   ${size}\nversion: {{ .Values.image.tag }}" > /chain-data/now.meta.txt
@@ -188,7 +188,7 @@ spec:
                   exit 1
                 fi
                 mkdir -p /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}
-                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} rsync -d -r ${BUCKET_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
+                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} cp -r ${BUCKET_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
               fi
           env:
             - name: CHAIN_PATH
@@ -223,7 +223,7 @@ spec:
                   exit 1
                 fi
                 mkdir -p /relaychain-data/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}
-                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} rsync -d -r ${BUCKET_URL}/${LATEST} /relaychain-data/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}/
+                gsutil {{ .Values.googleCloudSdk.gsutilFlags }} cp -r ${BUCKET_URL}/${LATEST} /relaychain-data/chains/${RELAY_CHAIN_PATH}/{{ $databasePath }}/
               fi
           env:
             - name: RELAY_CHAIN_PATH

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -51,7 +51,7 @@ googleCloudSdk:
   image:
     repository: google/cloud-sdk
     tag: slim # more lightweight than the full image and still contains gsutil
-  gsutilFlags: '-m -o "GSUtil:parallel_process_count=$(nproc --all)" -o "GSUtil:parallel_thread_count=2"'
+  gsutilFlags: '-m -o "GSUtil:parallel_process_count=$(nproc --all)" -o "GSUtil:parallel_thread_count=2" -o "GSUtil:use_gcloud_storage=True"'
   # serviceAccountKey: ""
 
 ## Reference to one or more secrets to be used when pulling images


### PR DESCRIPTION
Google has announced GA for the new [gcloud storage CLI](https://cloud.google.com/blog/products/storage-data-transfer/new-gcloud-storage-cli-for-your-data-transfers) which is expected to speed up transfers from GCS buckets.

I ran the benchmark using the new flag of gsutil CLI `-o "GSUtil:use_gcloud_storage=True"`. I had to slightly modify the command because the new `gcloud storage` utility does not support `rsync` command. I simply replaced it with recursive `cp`.

I ran cloud storage bucket sync 3 times using both old and new command format for each run. Total download time is measured using `time`.

## New format
`gsutil -o "GSUtil:use_gcloud_storage=True" -m -o "GSUtil:parallel_process_count=$(nproc --all)" -o "GSUtil:parallel_thread_count=2" cp -r gs://westend-blockstore-backups/westend-rocksdb-prune/20221011-035853 ./chain-data`

Run 1: 6m41.783s
Run 2: 6m41.816s
Run 3: 6m41.284s

**Average: ~6m41s**

## Old format
`gsutil -m -o "GSUtil:parallel_process_count=$(nproc --all)" -o "GSUtil:parallel_thread_count=2" rsync -d -r gs://westend-blockstore-backups/westend-rocksdb-prune/20221011-035853 ./chain-data`

Run 1: 8m13.306s
Run 2: 8m21.835s
Run 3: 8m19.779s

**Average: ~8m17s**

It means that the new command format is **~24% faster** compared to the old one.

Signed-off-by: bakhtin <a@bakhtin.net>