### PR TITLE
parity-bridge-common - slight alteration of serviceMonitor creation logic

### DIFF
--- a/charts/parity-bridge-common/Chart.yaml
+++ b/charts/parity-bridge-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: parity-bridge-common
 description: A Helm chart for parity-bridge-common
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/parity-bridge-common/templates/servicemonitor.yaml
+++ b/charts/parity-bridge-common/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled .Values.prometheus.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Were `prometheus.enabled: false` then the serviceMonitor would still be created and pointing at a non-existent endpoint.