### PR TITLE
Chore/upgrade actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,21 +20,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Helm
-      uses: azure/setup-helm@v1
+      uses: azure/setup-helm@v3
       with:
         version: v3.8.1
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.2.1
+      uses: helm/chart-testing-action@v2.3.1
 
     - name: Install additional Helm repos
       run: |
@@ -57,7 +57,7 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
 
     - name: Create kind cluster
-      uses: helm/kind-action@v1.2.0
+      uses: helm/kind-action@v1.4.0
       with:
         node_image: kindest/node:v1.21.10
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v3.3
       with:
         version: v3.8.1
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,7 @@ jobs:
       run: |
         changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
         if [[ -n "$changed" ]]; then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Run chart-testing (lint)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -20,16 +20,16 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
-          version: v3.4.0
+          version: v3.8.1
 
       - name: Install additional Helm repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.3
         with:
           version: v3.8.1
 


### PR DESCRIPTION
This moves several github actions to newer versions.

GHA are deprecating actions running on NodeJS version 12.  This means actions must be updated to using NodeJS 16 where applicable.

Additionally they are deprecating usage of the `::set-output` notation and replacing it with env files (which also necessitates an upgrade on several actions).

The only action that currently doesn't support the env file method for setting outputs currently used in this repository is `Azure/setup-helm` Although this looks to just be a case of upgrading the `@actions/*` deps and looks to be a very quick fix/release when they choose to do so.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/