### PR TITLE
[Node] fix echo command

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.2.3
+version: 4.2.4
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -147,8 +147,7 @@ spec:
                 echo -e "\nStart gsutil backup\n"
                 gsutil {{ .Values.googleCloudSdk.gsutilFlags }} cp -r /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/ ${BUCKET_URL}/${NOW}
                 size=$(gsutil du -s ${BUCKET_URL}/${NOW} | awk '{ print $1 }' )
-                echo -e "size:
-                  ${size}\nversion: {{ .Values.image.tag }}" > /chain-data/now.meta.txt
+                echo "size: ${size}\nversion: {{ .Values.image.tag }}" > /chain-data/now.meta.txt
                 gsutil cp /chain-data/now.meta.txt ${BUCKET_URL}/${NOW}.meta.txt
                 rm -f /chain-data/now.meta.txt
                 echo "${NOW}" > /chain-data/latest_version.meta.txt


### PR DESCRIPTION
`/bin/sh` and `/bin/bash` have completely different `echo` commands.
The current output is this 
![image](https://user-images.githubusercontent.com/24387396/199728363-d85949c5-d737-426b-9e62-fd492cc05a12.png)

After fix the output should look  like this: 
```
size: 431681890
version: master
```