### PR TITLE
Deprecate polkadot-runtime-exporter chart

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -78,5 +78,6 @@ jobs:
       run: |
         ct install \
         --target-branch ${{ github.event.repository.default_branch }} \
-        --excluded-charts charts/common
+        --excluded-charts charts/common \
+        --excluded-charts charts/polkadot-runtime-exporter
       if: steps.list-changed.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Parity's [Kubernetes Helm](https://helm.sh/) charts collection.
 - [Bridges Common Relay](charts/bridges-common-relay/README.md): deploy bridges-common-relay service
 - [Polkadot Basic Notification](charts/polkadot-basic-notification/README.md): deploy a chain notification bot
 - [Polkadot Introspector](charts/polkadot-introspector/README.md): deploy a chain monitoring and introspection service
-- [Polkadot Runtime Exporter](charts/polkadot-runtime-exporter/README.md): deploy a tool to collect runtime statistics
 - [Staking miner](charts/staking-miner/README.md): deploy the staking-miner for submitting solutions to NPoS elections
 - [Substrate faucet](charts/substrate-faucet/README.md): deploy Substrate Faucet service
 - [Substrate telemetry](charts/substrate-telemetry/README.md): deploy the Substrate Telemetry service

--- a/charts/polkadot-runtime-exporter/Chart.yaml
+++ b/charts/polkadot-runtime-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: polkadot-runtime-exporter
 description: A Helm chart to deploy runtime exporter (https://github.com/paritytech/polkadot-runtime-prom-exporter)
 type: application
-version: 1.1.1
+version: 1.2.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/polkadot-runtime-exporter/README.md
+++ b/charts/polkadot-runtime-exporter/README.md
@@ -1,5 +1,7 @@
 # Polkadot Runtime Exporter Helm Chart
 
+DEPRECATED: This chart is no longer maintained.
+
 ## TL;DR
 
 ```console


### PR DESCRIPTION
Mark the runtime-exporter chart as no longer maintained.