### PR TITLE
[parity-bridges-common] support for relay headers and messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/charts/*.tgz
+.idea

--- a/charts/parity-bridges-common/Chart.yaml
+++ b/charts/parity-bridges-common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: parity-bridges-common
 description: A Helm chart for parity-bridges-common
 type: application
-version: 0.1.1
+version: 0.2.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/parity-bridges-common/templates/deployment.yaml
+++ b/charts/parity-bridges-common/templates/deployment.yaml
@@ -11,8 +11,9 @@ spec:
       {{- include "parity-bridges-common.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -78,6 +79,17 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.secrets }}
+          volumeMounts:
+          - name: secrets
+            mountPath: "/secrets"
+            readOnly: true
+      volumes:
+      - name: secrets
+        secret:
+          secretName: {{ include "parity-bridges-common.fullname" . }}
+          optional: false
+          {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/parity-bridges-common/templates/deployment.yaml
+++ b/charts/parity-bridges-common/templates/deployment.yaml
@@ -34,15 +34,25 @@ spec:
           args:
             {{- if .Values.relayHeaders.enabled }}
             - "relay-headers {{ .Values.relayHeaders.name }}"
-            - "--source-host {{ .Values.relayHeaders.source.host }}"
-            - "--source-port {{ .Values.relayHeaders.source.port }}"
-            - "--target-host {{ .Values.relayHeaders.target.host }}"
-            - "--target-port {{ .Values.relayHeaders.target.port }}"
-            - "--target-signer {{ .Values.relayHeaders.target.signer }}"
+            {{- range $key, $value := .Values.relayHeaders.params }}
+            - "--{{ $key }} {{ $value }}"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.relayHeadersAndMessages.enabled }}
+            - "relay-headers-and-messages {{ .Values.relayHeadersAndMessages.name }}"
+            {{- range $key, $value := .Values.relayHeadersAndMessages.params }}
+            {{- if kindIs "slice" $value }}
+            {{- range $param := $value }}
+            - "--{{ $key }} {{ $param  }}"
+            {{- end }}
+            {{- else }}
+            - "--{{ $key }} {{ $value }}"
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.prometheus.enabled }}
             - "--prometheus-host 0.0.0.0"
             - "--prometheus-port {{ .Values.prometheus.port }}"
-            {{- end }}
             {{- end }}
             {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}

--- a/charts/parity-bridges-common/templates/secret.yaml
+++ b/charts/parity-bridges-common/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "parity-bridges-common.fullname" . }}
+  labels:
+    {{- include "parity-bridges-common.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- range $key, $val := .Values.secrets }}
+  {{ $key }}: {{ $val | b64enc }}
+{{- end -}}
+{{- end }}

--- a/charts/parity-bridges-common/values.yaml
+++ b/charts/parity-bridges-common/values.yaml
@@ -42,11 +42,15 @@ relayHeadersAndMessages:
     wococo-port: 9945
     bridge-hub-wococo-host: localhost
     bridge-hub-wococo-port: 8945
-    bridge-hub-wococo-signer: //Charlie
+    bridge-hub-wococo-signer-file: /secrets/bridge-hub-wococo-signer-file
     rococo-headers-to-bridge-hub-wococo-signer: //Bob
     rococo-parachains-to-bridge-hub-wococo-signer: //Bob
     bridge-hub-wococo-transactions-mortality: 4
     lane: ["00000001", "00000002"]
+
+# secrets will be mounted to pod /secrets/{key}
+secrets: {}
+  # bridge-hub-wococo-signer-file: //Charlie
 
 env: {}
   # RUST_LOG: 'runtime=trace'

--- a/charts/parity-bridges-common/values.yaml
+++ b/charts/parity-bridges-common/values.yaml
@@ -46,7 +46,7 @@ relayHeadersAndMessages:
     rococo-headers-to-bridge-hub-wococo-signer: //Bob
     rococo-parachains-to-bridge-hub-wococo-signer: //Bob
     bridge-hub-wococo-transactions-mortality: 4
-    lane: [ "00000001", "00000002" ]
+    lane: ["00000001", "00000002"]
 
 env: {}
   # RUST_LOG: 'runtime=trace'

--- a/charts/parity-bridges-common/values.yaml
+++ b/charts/parity-bridges-common/values.yaml
@@ -27,7 +27,7 @@ relayHeaders:
     target-signer: //Bob
 
 relayHeadersAndMessages:
-  enabled: true
+  enabled: false
   name: bridge-hub-rococo-bridge-hub-wococo
   params:
     rococo-host: localhost

--- a/charts/parity-bridges-common/values.yaml
+++ b/charts/parity-bridges-common/values.yaml
@@ -24,29 +24,31 @@ relayHeaders:
     source-port: 9955
     target-host: ws://rpc.example
     target-port: 9944
-    target-signer: //Bob
+    # target-signer: //Bob
+    # or
+    # target-signer-file: /path/to/bob/seed
 
 relayHeadersAndMessages:
   enabled: false
   name: bridge-hub-rococo-bridge-hub-wococo
-  params:
-    rococo-host: localhost
-    rococo-port: 9942
-    bridge-hub-rococo-host: localhost
-    bridge-hub-rococo-port: 8943
-    bridge-hub-rococo-signer: //Charlie
-    wococo-headers-to-bridge-hub-rococo-signer: //Bob
-    wococo-parachains-to-bridge-hub-rococo-signer: //Bob
-    bridge-hub-rococo-transactions-mortality: 4
-    wococo-host: localhost
-    wococo-port: 9945
-    bridge-hub-wococo-host: localhost
-    bridge-hub-wococo-port: 8945
-    bridge-hub-wococo-signer-file: /secrets/bridge-hub-wococo-signer-file
-    rococo-headers-to-bridge-hub-wococo-signer: //Bob
-    rococo-parachains-to-bridge-hub-wococo-signer: //Bob
-    bridge-hub-wococo-transactions-mortality: 4
-    lane: ["00000001", "00000002"]
+  params: {}
+    #  rococo-host: localhost
+    #  rococo-port: 9942
+    #  bridge-hub-rococo-host: localhost
+    #  bridge-hub-rococo-port: 8943
+    #  bridge-hub-rococo-signer: //Charlie
+    #  wococo-headers-to-bridge-hub-rococo-signer: //Bob
+    #  wococo-parachains-to-bridge-hub-rococo-signer: //Bob
+    #  bridge-hub-rococo-transactions-mortality: 4
+    #  wococo-host: localhost
+    #  wococo-port: 9945
+    #  bridge-hub-wococo-host: localhost
+    #  bridge-hub-wococo-port: 8945
+    #  bridge-hub-wococo-signer-file: /secrets/bridge-hub-wococo-signer-file
+    #  rococo-headers-to-bridge-hub-wococo-signer: //Bob
+    #  rococo-parachains-to-bridge-hub-wococo-signer: //Bob
+    #  bridge-hub-wococo-transactions-mortality: 4
+    #  lane: ["00000001", "00000002"]
 
 # secrets will be mounted to pod /secrets/{key}
 secrets: {}

--- a/charts/parity-bridges-common/values.yaml
+++ b/charts/parity-bridges-common/values.yaml
@@ -19,13 +19,34 @@ serviceAccount:
 relayHeaders:
   enabled: false
   name: rococo-to-bridge-hub-wococo
-  source:
-    host: ws://rpc.example
-    port: 9955
-  target:
-    host: ws://rpc.example
-    port: 9944
-    signer: //Bob
+  params:
+    source-host: ws://rpc.example
+    source-port: 9955
+    target-host: ws://rpc.example
+    target-port: 9944
+    target-signer: //Bob
+
+relayHeadersAndMessages:
+  enabled: true
+  name: bridge-hub-rococo-bridge-hub-wococo
+  params:
+    rococo-host: localhost
+    rococo-port: 9942
+    bridge-hub-rococo-host: localhost
+    bridge-hub-rococo-port: 8943
+    bridge-hub-rococo-signer: //Charlie
+    wococo-headers-to-bridge-hub-rococo-signer: //Bob
+    wococo-parachains-to-bridge-hub-rococo-signer: //Bob
+    bridge-hub-rococo-transactions-mortality: 4
+    wococo-host: localhost
+    wococo-port: 9945
+    bridge-hub-wococo-host: localhost
+    bridge-hub-wococo-port: 8945
+    bridge-hub-wococo-signer: //Charlie
+    rococo-headers-to-bridge-hub-wococo-signer: //Bob
+    rococo-parachains-to-bridge-hub-wococo-signer: //Bob
+    bridge-hub-wococo-transactions-mortality: 4
+    lane: [ "00000001", "00000002" ]
 
 env: {}
   # RUST_LOG: 'runtime=trace'


### PR DESCRIPTION

```
RUST_LOG=runtime=trace,rpc=trace,bridge=trace \
    ~/local_bridge_testing/bin/substrate-relay relay-headers-and-messages bridge-hub-rococo-bridge-hub-wococo \
    --rococo-host localhost \
    --rococo-port 9942 \
    --bridge-hub-rococo-host localhost \
    --bridge-hub-rococo-port 8943 \
    --bridge-hub-rococo-signer //Charlie \
    --wococo-headers-to-bridge-hub-rococo-signer //Bob \
    --wococo-parachains-to-bridge-hub-rococo-signer //Bob \
    --bridge-hub-rococo-transactions-mortality 4 \
    --wococo-host localhost \
    --wococo-port 9945 \
    --bridge-hub-wococo-host localhost \
    --bridge-hub-wococo-port 8945 \
    --bridge-hub-wococo-signer //Charlie \
    --rococo-headers-to-bridge-hub-wococo-signer //Bob \
    --rococo-parachains-to-bridge-hub-wococo-signer //Bob \
    --bridge-hub-wococo-transactions-mortality 4 \
    --lane 00000001 \
    --lane 00000002
```