### PR TITLE
Add log read permission to testnet-manager RBAC

### DIFF
--- a/charts/testnet-manager/Chart.yaml
+++ b/charts/testnet-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: testnet-manager
 description: A Helm chart to deploy testnet-manager
 type: application
 version: 1.1.1
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/testnet-manager/templates/rbac.yaml
+++ b/charts/testnet-manager/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $fullName }}-pod-reader
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "pods/log"]
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is required to enable the simple log API