### PR TITLE
SidecarLivenessProbe was added to node helm

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.2.6
+version: 4.2.7
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -33,6 +33,10 @@ spec:
     - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort | int }}
       name: prom-relaychain
     {{- end }}
+    {{- if or .Values.node.enableSidecarReadinessProbe .Values.node.enableSidecarLivenessProbe }}
+    - port: 8001
+      name: http-ws-health-exporter
+    {{- end }}
 ---
 {{range $i := until (max .Values.autoscaling.maxReplicas .Values.node.replicas | int) }}
 {{- if $.Values.node.perNodeServices.apiService.enabled }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -752,7 +752,7 @@ spec:
               path: /
               port: admin
         {{- end}}
-        {{ if .Values.node.enableSidecarReadinessProbe }}
+        {{- if or .Values.node.enableSidecarReadinessProbe .Values.node.enableSidecarLivenessProbe }}
         - name: ws-health-exporter
           image: {{ .Values.wsHealthExporter.image.repository }}:{{ .Values.wsHealthExporter.image.tag }}
           env:
@@ -760,10 +760,20 @@ spec:
               value: ws://127.0.0.1:9944
           resources:
           {{- toYaml .Values.wsHealthExporter.resources | nindent 12 }}
+          {{- if .Values.node.enableSidecarReadinessProbe }}
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: 8001
+          {{- end }}
+          {{- if .Values.node.enableSidecarLivenessProbe }}
+          livenessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 8001
+            failureThreshold: 10
+            periodSeconds: 60
+          {{- end }}
         {{- end }}
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -383,6 +383,7 @@ node:
   ## Enable Node readiness probe through `paritytech/ws-health-exporter` running as a sidecar container
   ##
   enableSidecarReadinessProbe: false
+  enableSidecarLivenessProbe: false
 
   ## Resource limits & requests
   ##


### PR DESCRIPTION
Unfortunately, RPC nodes sometimes frozens and do not accept new WS connections. We have to restart nodes in this case. I handled exceptions for the main part of the exporter code (in sidecar). I'm going to improve the code including exception handling.

Signed-off-by: kogeler <roman.gavrilov@parity.io>