### PR TITLE
[node] fix listen-addr

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.2.7
+version: 4.2.8
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -635,6 +635,10 @@ spec:
                 --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT_WS}/ws \
                 {{- end }}
                 {{- end }}
+                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
+                {{- if and (not .Values.node.isParachain) .Values.node.perNodeServices.relayP2pService.ws.enabled }}
+                --listen-addr=/ip4/0.0.0.0/tcp/30334/ws \
+                {{- end }}
 
           env:
             - name: CHAIN


### PR DESCRIPTION
Revert commit https://github.com/paritytech/helm-charts/pull/189/commits/6f87137c008e761e160476b31cb67b446ce973d2


## Description
Old pod args: 
```
...
        --execution wasm \
        --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT} \
        --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
```
Service:
```
sts-node-0-relay-chain-p2p        NodePort    ip   <none>        30333:{RELAY_CHAIN_P2P_PORT}/TCP              1d
```

When we try to open ptp port to internet we create service `NodePort`. Service port-forward `RELAY_CHAIN_P2P_PORT->30333` but we are listing only  `RELAY_CHAIN_P2P_PORT` not `30333`. 


New pod args:
```
...
        --execution wasm \
        --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT} \
        --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
        --listen-addr=/ip4/0.0.0.0/tcp/30333 \
```