### PR TITLE
Remove wrong --listen-addr flags

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.2.8
+version: 4.2.11
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -553,7 +553,6 @@ spec:
                 {{- if .Values.node.perNodeServices.paraP2pService.enabled }}
                 {{- if .Values.node.perNodeServices.paraP2pService.ws.enabled }}
                 --listen-addr=/ip4/0.0.0.0/tcp/30335/ws \
-                --listen-addr=/ip4/0.0.0.0/tcp/${PARA_CHAIN_P2P_PORT_WS}/ws \
                 {{- end }}
                 {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
                 --public-addr=/ip4/${EXTERNAL_IP}/tcp/${PARA_CHAIN_P2P_PORT} \
@@ -561,7 +560,6 @@ spec:
                 --public-addr=/ip4/${EXTERNAL_IP}/tcp/${PARA_CHAIN_P2P_PORT_WS}/ws \
                 {{- end }}
                 {{- end }}
-                --listen-addr=/ip4/0.0.0.0/tcp/${PARA_CHAIN_P2P_PORT} \
                 {{- end }}
                 {{- end }}
                 {{- if .Values.node.persistGeneratedNodeKey }}
@@ -630,16 +628,11 @@ spec:
                 --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT_WS}/ws \
                 {{- end }}
                 {{- end }}
-                --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
-                {{- if and (not .Values.node.isParachain) .Values.node.perNodeServices.relayP2pService.ws.enabled }}
-                --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT_WS}/ws \
-                {{- end }}
-                {{- end }}
-                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
                 {{- if and (not .Values.node.isParachain) .Values.node.perNodeServices.relayP2pService.ws.enabled }}
                 --listen-addr=/ip4/0.0.0.0/tcp/30334/ws \
                 {{- end }}
-
+                {{- end }}
+                --listen-addr=/ip4/0.0.0.0/tcp/30333 \
           env:
             - name: CHAIN
               value: {{ .Values.node.chain }}


### PR DESCRIPTION
Extra `--listen-addr` flag were set to the externally visible instead of the internal pod port and had no effect.