### PR TITLE
Fix faucet chart testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,7 @@ jobs:
       run: |
         changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
         if [[ -n "$changed" ]]; then
-          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "changed=$changed" >> $GITHUB_OUTPUT
         fi
 
     - name: Run chart-testing (lint)
@@ -53,14 +53,14 @@ jobs:
         ct lint \
           --target-branch ${{ github.event.repository.default_branch }} \
           --lint-conf chart-testing/lintconf.yaml \
-          --excluded-charts charts/common
-      if: steps.list-changed.outputs.changed == 'true'
+          --charts ${{ steps.list-changed.outputs.changed }}
+      if: steps.list-changed.outputs.changed
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.4.0
       with:
         node_image: kindest/node:v1.21.10
-      if: steps.list-changed.outputs.changed == 'true'
+      if: steps.list-changed.outputs.changed
 
     - name: Replace secrets in Helm charts
       env:
@@ -72,12 +72,11 @@ jobs:
           sed -i "s/__GITHUB_SECRET_SMF_BOT_MATRIX_ACCESS_TOKEN/$SMF_BOT_MATRIX_ACCESS_TOKEN/g" $f
           sed -i "s/__GITHUB_SECRET_STAKING_MINER_CONFIG_SEED/$STAKING_MINER_CONFIG_SEED/g" $f
         done
-      if: steps.list-changed.outputs.changed == 'true'
+      if: steps.list-changed.outputs.changed
 
     - name: Run chart-testing (install)
       run: |
         ct install \
         --target-branch ${{ github.event.repository.default_branch }} \
-        --excluded-charts charts/common \
-        --excluded-charts charts/polkadot-runtime-exporter
-      if: steps.list-changed.outputs.changed == 'true'
+        --charts ${{ steps.list-changed.outputs.changed }}
+      if: steps.list-changed.outputs.changed

--- a/chart-testing/run-local.sh
+++ b/chart-testing/run-local.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+changed="$(ct list-changed --target-branch main)"
+targetBranch="$(git branch --show-current)"
+ct lint-and-install \
+  --target-branch="${targetBranch}" \
+  --charts="${changed}" \
+  --excluded-charts=charts/polkadot-runtime-exporter \
+  --validate-chart-schema=false \
+  --lint-conf="chart-testing/lintconf.yaml"

--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 1.2.2
+version: 1.2.3
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/ci/kind-values.yaml
+++ b/charts/substrate-faucet/ci/kind-values.yaml
@@ -11,5 +11,5 @@ bot:
     SMF_BOT_MATRIX_ACCESS_TOKEN: "__GITHUB_SECRET_SMF_BOT_MATRIX_ACCESS_TOKEN"
 
   config:
-    SMF_BOT_MATRIX_SERVER: "https://matrix.org"
-    SMF_BOT_MATRIX_BOT_USER_ID: "@parity_ci_bot:matrix.org"
+    SMF_BOT_MATRIX_SERVER: "https://m.parity.io"
+    SMF_BOT_MATRIX_BOT_USER_ID: "@helm-charts-bot:parity.io"


### PR DESCRIPTION
- Fix faucet chart testing by migrating to Parity's new Matrix server credentials 
- Add useful script to run chart-testing locally 
- Improve pr github workflow to only test changed charts

This fixes issues of PR that can't be merged due to failure of an unrelated chart, see eg: https://github.com/paritytech/helm-charts/pull/205#issuecomment-1387172057