### PR TITLE
[Faucet] Allow disabling bot and enabling server external access via ingress

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 1.2.3
+version: 1.3.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/bot-deployment.yaml
+++ b/charts/substrate-faucet/templates/bot-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.bot.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -65,3 +66,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/charts/substrate-faucet/templates/bot-secret.yaml
+++ b/charts/substrate-faucet/templates/bot-secret.yaml
@@ -1,4 +1,4 @@
-{{- if (not .Values.bot.existingSecret) -}}
+{{- if and (.Values.bot.enabled) (not .Values.bot.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/substrate-faucet/templates/ingress.yaml
+++ b/charts/substrate-faucet/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "faucet.serverLabels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName -}}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: {{ .Release.Name }}-server
+                port:
+                  name: http
+  tls:
+  {{- with .Values.ingress.tls }}
+  {{- toYaml . | nindent 6 }}
+  {{- end }}
+{{- end }}

--- a/charts/substrate-faucet/templates/server-deployment.yaml
+++ b/charts/substrate-faucet/templates/server-deployment.yaml
@@ -49,6 +49,12 @@ spec:
               value: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
             - name: SMF_BACKEND_DEPLOYED_TIME
               value: {{ now | date "2006-01-02T15:04:05" | quote }}
+            - name: SMF_BACKEND_EXTERNAL_ACCESS
+              value: {{ .Values.server.externalAccess | quote }}
+          ports:
+            - name: http
+              containerPort: 5555
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready

--- a/charts/substrate-faucet/templates/server-service.yaml
+++ b/charts/substrate-faucet/templates/server-service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.server.config.SMF_BACKEND_PORT }}
-      name: metrics
+    - name: http
+      port: 5555
+      targetPort: 5555
       protocol: TCP
   selector:
-    {{- include "faucet.serverSelectorLabels" . | nindent 8 }}
-
+    {{ include "faucet.serverSelectorLabels" . | nindent 4 }}

--- a/charts/substrate-faucet/templates/servicemonitor.yaml
+++ b/charts/substrate-faucet/templates/servicemonitor.yaml
@@ -2,24 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-bot
-spec:
-  selector:
-    matchLabels:
-    {{- include "faucet.botSelectorLabels" . | nindent 8 }}
-  endpoints:
-    - port: metrics
-      interval: 15s
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
   name: {{ .Release.Name }}-server
 spec:
   selector:
     matchLabels:
     {{- include "faucet.serverSelectorLabels" . | nindent 8 }}
   endpoints:
-    - port: metrics
+    - port: http
       interval: 15s
 {{- end }}

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -14,6 +14,7 @@ server:
     pullPolicy: Always
   existingConfigMap: ''
   existingSecret: ''
+  externalAccess: false
   secret:
     SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC: "this is a fake mnemonic"
   config:
@@ -21,8 +22,10 @@ server:
     SMF_BACKEND_NETWORK_DECIMALS: 12
     SMF_BACKEND_INJECTED_TYPES: '{}'
     SMF_BACKEND_PORT: 5555
-
+    SMF_BACKEND_DRIP_AMOUNT: 10
+    SMF_BACKEND_RECAPTCHA_SECRET: ''
 bot:
+  enabled: true
   image:
     repository: paritytech/faucet-bot
     tag: latest
@@ -39,6 +42,11 @@ bot:
     SMF_BOT_NETWORK_DECIMALS: 12
     SMF_BOT_NETWORK_UNIT: "UNIT"
     SMF_BOT_FAUCET_IGNORE_LIST: ''
+ingress:
+  enabled: false
+#    annotations:
+#    host: example.com
+#    tls:
 
 extraLabels: []
 


### PR DESCRIPTION
- Add configuration for faucet server external access introduced in https://github.com/paritytech/substrate-matrix-faucet/pull/192
- Add optional faucet ingress 