### PR TITLE
Set faucet recaptcha secret as Kubernetes secret instead of configmap

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 1.3.0
+version: 1.3.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -17,13 +17,13 @@ server:
   externalAccess: false
   secret:
     SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC: "this is a fake mnemonic"
+    SMF_BACKEND_RECAPTCHA_SECRET: "fakeRecaptchaSecret"
   config:
     SMF_BACKEND_RPC_ENDPOINT: "https://example.com/"
     SMF_BACKEND_NETWORK_DECIMALS: 12
     SMF_BACKEND_INJECTED_TYPES: '{}'
     SMF_BACKEND_PORT: 5555
     SMF_BACKEND_DRIP_AMOUNT: 10
-    SMF_BACKEND_RECAPTCHA_SECRET: ''
 bot:
   enabled: true
   image:
@@ -33,7 +33,6 @@ bot:
   existingConfigMap: ""
   existingSecret: ""
   secret:
-    # your bot access token here is how to find it https://t2bot.io/docs/access_tokens/
     SMF_BOT_MATRIX_ACCESS_TOKEN: "ThisIsNotARealAccessToken"
   config:
     SMF_BOT_MATRIX_SERVER: "https://matrix.org"


### PR DESCRIPTION
This prevents a bug where the env var would be defined twice, once as secret and once as configmap