### PR TITLE
Add parachain-commander command support to polkadot-introspector

### DIFF
--- a/charts/polkadot-introspector/Chart.yaml
+++ b/charts/polkadot-introspector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: polkadot-introspector
 description: A Helm chart to deploy polkadot-introspector
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "0.1.0"
 maintainers:
   - name: Parity

--- a/charts/polkadot-introspector/templates/deployment.yaml
+++ b/charts/polkadot-introspector/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           args:
             - -c
             - |
-              exec polkadot-introspector \
+              exec polkadot-introspector/polkadot/polkadot-introspector \
               {{-  if eq .Values.introspector.role "block-time-monitor"}}
               block-time-monitor \
               --ws {{ join "," .Values.introspector.rpcNodes }} \

--- a/charts/polkadot-introspector/templates/deployment.yaml
+++ b/charts/polkadot-introspector/templates/deployment.yaml
@@ -41,6 +41,17 @@ spec:
               --ws {{ join "," .Values.introspector.rpcNodes }} \
               prometheus --port {{ .Values.introspector.prometheusPort }}
               {{- end }}
+              {{-  if eq .Values.introspector.role "parachain-commander"}}
+              parachain-commander \
+              --ws {{ join "," .Values.introspector.rpcNodes }} \
+              {{- range .Values.introspector.paraIds }}
+              --para-id {{ . }} \
+              {{- end }}
+              prometheus --port {{ .Values.introspector.prometheusPort }}
+              {{- end }}
+              {{- range .Values.introspector.extraArgs }}
+              {{ . }} \
+              {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.introspector.prometheusPort }}

--- a/charts/polkadot-introspector/values.yaml
+++ b/charts/polkadot-introspector/values.yaml
@@ -2,7 +2,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: lazam/introspector #To be replaced once public image is available
+  repository: paritytech/polkadot-introspector
   pullPolicy: Always
   tag: latest
 
@@ -15,7 +15,9 @@ introspector:
   rpcNodes:
     - wss://rpc.polkadot.io:443
     - wss://kusama-rpc.polkadot.io:443
+  paraIds: []
   prometheusPort: 9615
+  extraArgs: []
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Implement support to deploy the polkadot-introspector in [parachain-commander mode](https://github.com/paritytech/polkadot-introspector/tree/d3d4b3e4b718dcf2254a93a0cfc1c88c4a147978/src/pc)