### PR TITLE
Set correct faucet service labels to fix servicemonitor targeting

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 2.1.0
+version: 2.1.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/_helpers.tpl
+++ b/charts/substrate-faucet/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 */}}
 {{- define "faucet.labels" -}}
 helm.sh/chart: {{ include "faucet.chart" . }}
+{{ include "faucet.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
Faucet Service monitors were not working as the correct tags were absent from the Faucet Service.