### PR TITLE
Configure external validators addresses for testnet-manager

### DIFF
--- a/charts/testnet-manager/Chart.yaml
+++ b/charts/testnet-manager/Chart.yaml
@@ -3,7 +3,7 @@ name: testnet-manager
 description: A Helm chart to deploy testnet-manager
 type: application
 version: 1.1.2
-appVersion: "1.2.1"
+appVersion: "1.3.0"
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/testnet-manager/templates/_helpers.tpl
+++ b/charts/testnet-manager/templates/_helpers.tpl
@@ -68,3 +68,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the external-validators configmap to use
+*/}}
+{{- define "testnet-manager.external-validators-configmap" -}}
+{{- printf "%s-external-validators" (include "testnet-manager.fullname" .) }}
+{{- end }}

--- a/charts/testnet-manager/templates/deployment.yaml
+++ b/charts/testnet-manager/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           env:
           - name: NAMESPACE
             value: {{ .Release.Namespace | quote }}
+          {{ if .Values.externalValidators }}
+          - name: EXTERNAL_VALIDATORS_CONFIGMAP
+            value: {{ include "testnet-manager.external-validators-configmap" . }}
+          {{- end }}
           {{- with .Values.extraEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/testnet-manager/templates/external-validators-configmap.yaml
+++ b/charts/testnet-manager/templates/external-validators-configmap.yaml
@@ -1,0 +1,10 @@
+{{ if .Values.externalValidators }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "testnet-manager.external-validators-configmap" . }}
+data:
+{{- range $validatorName, $validatorAddress := .Values.externalValidators }}
+  {{ $validatorName }}: {{ $validatorAddress | quote }}
+{{- end }}
+{{- end }}

--- a/charts/testnet-manager/values.yaml
+++ b/charts/testnet-manager/values.yaml
@@ -25,6 +25,8 @@ args:
     - "--enable-stdio-inheritance"
     - "--workers=1"
 
+externalValidators: []
+
 ## Extra Environment variables
 ##
 extraEnv: []


### PR DESCRIPTION
Allow configuring the list of external validators address as a configmap.

Linked to https://github.com/paritytech/testnet-manager/pull/63