### PR TITLE
Update polkadot-introspector command flags following the 0.2.1 release

### DIFF
--- a/charts/polkadot-introspector/Chart.yaml
+++ b/charts/polkadot-introspector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: polkadot-introspector
 description: A Helm chart to deploy polkadot-introspector
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "1.0.0"
 maintainers:
   - name: Parity

--- a/charts/polkadot-introspector/templates/_helpers.tpl
+++ b/charts/polkadot-introspector/templates/_helpers.tpl
@@ -63,3 +63,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define a regex matcher to check if the role is supported
+*/}}
+{{- define "introspector.rolesSupported" -}}
+{{- "^(block-time|parachain-tracer)$" }}
+{{- end }}

--- a/charts/polkadot-introspector/templates/deployment.yaml
+++ b/charts/polkadot-introspector/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ $rolesSupported := include "introspector.rolesSupported" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,15 +36,13 @@ spec:
           args:
             - -c
             - |
-              exec polkadot-introspector/{{ .Values.introspector.runtime }}/polkadot-introspector \
-              {{-  if eq .Values.introspector.role "block-time-monitor"}}
-              block-time-monitor \
-              --ws {{ join "," .Values.introspector.rpcNodes }} \
-              prometheus --port {{ .Values.introspector.prometheusPort }}
-              {{- end }}
-              {{-  if eq .Values.introspector.role "parachain-commander"}}
-              parachain-commander \
-              --ws {{ join "," .Values.introspector.rpcNodes }} \
+              {{- if not (regexMatch $rolesSupported .Values.introspector.role) }}
+              {{- fail (printf "Error: introspector.role='%s' is not supported, it must be validated by this regex '%s'" .Values.introspector.role $rolesSupported) }}
+              {{- else }}
+              {{-  if eq .Values.introspector.role "block-time"}}
+              exec polkadot-introspector/{{ .Values.introspector.runtime }}/polkadot-block-time \
+              {{- else if eq .Values.introspector.role "parachain-tracer"}}
+              exec polkadot-introspector/{{ .Values.introspector.runtime }}/polkadot-parachain-tracer \
               {{- if .Values.introspector.enableAllParas }}
               --all \
               {{- else }}
@@ -51,10 +50,12 @@ spec:
               --para-id {{ . }} \
               {{- end }}
               {{- end }}
-              prometheus --port {{ .Values.introspector.prometheusPort }}
               {{- end }}
+              --ws {{ join "," .Values.introspector.rpcNodes }} \
+              prometheus --port {{ .Values.introspector.prometheusPort }}
               {{- range .Values.introspector.extraArgs }}
               {{ . }} \
+              {{- end }}
               {{- end }}
           ports:
             - name: http

--- a/charts/polkadot-introspector/values.yaml
+++ b/charts/polkadot-introspector/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets: []
 replicas: 1
 
 introspector:
-  role: block-time-monitor
+  role: block-time
   rpcNodes:
     - wss://rpc.polkadot.io:443
     - wss://kusama-rpc.polkadot.io:443


### PR DESCRIPTION
2 roles are supported `block-time` and `parachain-tracer` so we validate that those values are correctly set.