### PR TITLE
[node] Fix ServiceMonitor for collators

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.6.1
+version: 4.7.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/service.yaml
+++ b/charts/node/templates/service.yaml
@@ -42,7 +42,7 @@ spec:
     - port: {{ .Values.node.prometheus.port | int }}
       name: prometheus
     {{- end }}
-    {{- if $.Values.node.collatorRelayChain.prometheus.enabled }}
+    {{- if and $.Values.node.collatorRelayChain.prometheus.enabled (not $.Values.node.perNodeServices.apiService.enabled) }}
     - port: {{ $.Values.node.perNodeServices.apiService.relayChainPrometheusPort | int }}
       name: prom-relaychain
     {{- end }}

--- a/charts/node/templates/serviceMonitor.yaml
+++ b/charts/node/templates/serviceMonitor.yaml
@@ -34,34 +34,7 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-  namespaceSelector:
-    matchNames:
-      - {{ $.Release.Namespace }}
-  {{- with $.Values.node.serviceMonitor.targetLabels }}
-  targetLabels:
-  {{- toYaml .| nindent 4 }}
-  {{- end}}
-{{- end }}
----
-{{- if and .Values.node.serviceMonitor.enabled .Values.node.collatorRelayChain.prometheus.enabled }}
-{{ $fullname :=  include "node.fullname" . }}
-{{ $serviceLabels :=  include "node.serviceLabels" .  }}
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: {{ $fullname }}-relaychain
-  {{- if $.Values.node.serviceMonitor.namespace }}
-  namespace: {{ $.Values.node.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ $.Release.Namespace }}
-  {{- end }}
-  labels:
-    {{- include "node.labels" . | nindent 4 }}
-spec:
-  selector:
-    matchLabels:
-      {{- $serviceLabels | nindent 6 }}
-  endpoints:
+  {{- if .Values.node.collatorRelayChain.prometheus.enabled }}
     - port: prom-relaychain
       path: /metrics
     {{- if $.Values.node.serviceMonitor.interval }}
@@ -79,6 +52,7 @@ spec:
       metricRelabelings:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+  {{- end }}
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace }}


### PR DESCRIPTION
if `collatorRelayChain.prometheus.enabled` is set to true 3 targets are created:
- Service: `{{ $fullname }}` - port: `prom-relaychain` 
 - Service: `{{ $fullname }}-{{ $i }}` - port: `prom-relaychain` 
- Service: `{{ $fullname }}-{{ $i }}` - port: `prometheus`



## Changes:
1. Remove `prom-relaychain` port from  `{{ $fullname }}`  service.
2. Merge  2 ServiceMonitor in one. 