### PR TITLE
Propagate labels to Pods on bridges-common-relay chart

### DIFF
--- a/charts/bridges-common-relay/Chart.yaml
+++ b/charts/bridges-common-relay/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bridges-common-relay
 description: A Helm chart for bridges-common-relay
 type: application
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/bridges-common-relay/templates/deployment.yaml
+++ b/charts/bridges-common-relay/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "bridges-common-relay.selectorLabels" . | nindent 8 }}
+        {{- include "bridges-common-relay.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Update `bridges-common-relay` template to propagate Deployment labels to Pods it creates. It would propagate labels set in `extraLabels`.