### PR TITLE
Propagate labels to Pods on staking-miner

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 2.1.3
+version: 2.1.4
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/deployment.yaml
+++ b/charts/substrate-faucet/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "faucet.selectorLabels" . | nindent 8 }}
+        {{- include "faucet.labels" . | nindent 8 }}
       annotations:
         configmap/checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         secret/checksum: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Update staking-miner chart to propagate labels configured on Deployment to the Pods it spawns