### PR TITLE
Reworking faucet configs: part 1

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,11 +64,15 @@ jobs:
 
     - name: Replace secrets in Helm charts
       env:
+        SMF_CONFIG_MATRIX_ACCESS_TOKEN: ${{ secrets.SMF_CONFIG_MATRIX_ACCESS_TOKEN }}
+        # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
         SMF_BOT_MATRIX_ACCESS_TOKEN: ${{ secrets.SMF_BOT_MATRIX_ACCESS_TOKEN }}
         STAKING_MINER_CONFIG_SEED: ${{ secrets.STAKING_MINER_CONFIG_SEED }}
       run: |
         shopt -s globstar
         for f in $(find **/ci/*-values.yaml); do
+          sed -i "s/__GITHUB_SECRET_SMF_CONFIG_MATRIX_ACCESS_TOKEN/$SMF_CONFIG_MATRIX_ACCESS_TOKEN/g" $f
+          # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
           sed -i "s/__GITHUB_SECRET_SMF_BOT_MATRIX_ACCESS_TOKEN/$SMF_BOT_MATRIX_ACCESS_TOKEN/g" $f
           sed -i "s/__GITHUB_SECRET_STAKING_MINER_CONFIG_SEED/$STAKING_MINER_CONFIG_SEED/g" $f
         done

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -64,7 +64,8 @@ jobs:
 
     - name: Replace secrets in Helm charts
       env:
-        SMF_CONFIG_MATRIX_ACCESS_TOKEN: ${{ secrets.SMF_CONFIG_MATRIX_ACCESS_TOKEN }}
+        # TODO: rename the secret to avoid confusion
+        SMF_CONFIG_MATRIX_ACCESS_TOKEN: ${{ secrets.SMF_BOT_MATRIX_ACCESS_TOKEN }}
         # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
         SMF_BOT_MATRIX_ACCESS_TOKEN: ${{ secrets.SMF_BOT_MATRIX_ACCESS_TOKEN }}
         STAKING_MINER_CONFIG_SEED: ${{ secrets.STAKING_MINER_CONFIG_SEED }}

--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 2.1.4
+version: 2.2.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/README.md
+++ b/charts/substrate-faucet/README.md
@@ -8,15 +8,11 @@ To deploy a Westend faucet:
 ```console
 helm repo add parity https://paritytech.github.io/helm-charts/
 helm install substrate-faucet parity/substrate-faucet \
-    --set faucet.secret.SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC="//Alice" \
-    --set faucet.secret.SMF_BOT_MATRIX_ACCESS_TOKEN="******" \
-    --set faucet.config.SMF_BACKEND_RPC_ENDPOINT="wss://westend-rpc.polkadot.io/" \
-    --set faucet.config.SMF_BACKEND_INJECTED_TYPES='{}' \
-    --set faucet.config.SMF_BACKEND_NETWORK_DECIMALS='12' \
-    --set faucet.config.SMF_BOT_MATRIX_SERVER="https://matrix.org" \
-    --set faucet.config.SMF_BOT_MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org" \
-    --set faucet.config.SMF_BOT_NETWORK_UNIT="WND" \
-    --set faucet.config.SMF_BOT_DRIP_AMOUNT="1"
+    --set faucet.secret.SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC="//Alice" \
+    --set faucet.secret.SMF_CONFIG_MATRIX_ACCESS_TOKEN="******" \
+    --set faucet.config.SMF_CONFIG_MATRIX_SERVER="https://matrix.org" \
+    --set faucet.config.SMF_CONFIG_MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org" 
+    --set faucet.config.SMF_CONFIG_NETWORK="westend" 
 ```
 
 ## Parameters
@@ -33,23 +29,18 @@ helm install substrate-faucet parity/substrate-faucet \
 
 ### Faucet parameters
 
-| Name                                                | Description                                                                                             | Value                         |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `faucet.existingConfigMap`                          | existingConfigMap                                                                                       | `""`                          |
-| `faucet.existingSecret`                             | existingSecret                                                                                          | `""`                          |
-| `faucet.externalAccess`                             | externalAccess                                                                                          | `false`                       |
-| `faucet.secret.SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC` | Mnemonic seed for the faucet account                                                                    | `this is a fake mnemonic`     |
-| `faucet.secret.SMF_BACKEND_RECAPTCHA_SECRET`        | A secret recaptcha token used to validate external requests                                             | `fakeRecaptchaSecret`         |
-| `faucet.config.SMF_BACKEND_RPC_ENDPOINT`            | WS RPC node endpoint                                                                                    | `wss://example.com/`        |
-| `faucet.config.SMF_BACKEND_NETWORK_DECIMALS`        | Number of decimal for the network                                                                       | `12`                          |
-| `faucet.config.SMF_BACKEND_INJECTED_TYPES`          | To set if any type must be overriden                                                                    | `{}`                          |
-| `faucet.config.SMF_BACKEND_FAUCET_BALANCE_CAP`      | The bot wil verify this limit before sending tokens. If the account requesting tokens has more then the bot will not send tokens                                                                    | `100`                          |
-| `faucet.secret.SMF_BOT_MATRIX_ACCESS_TOKEN`         | Matrix Bot access token                                                                                 | `ThisIsNotARealAccessToken`   |
-| `faucet.config.SMF_BOT_DRIP_AMOUNT`                 | Default amount of tokens to send                                                                        | `10`                          |
-| `faucet.config.SMF_BOT_MATRIX_SERVER`               | Matrix server URL                                                                                       | `https://matrix.org`          |
-| `faucet.config.SMF_BOT_MATRIX_BOT_USER_ID`          | Bot user ID                                                                                             | `@test_bot_faucet:matrix.org` |
-| `faucet.config.SMF_BOT_NETWORK_UNIT`                | Token unit for the network                                                                              | `UNIT`                        |
-| `faucet.config.SMF_BOT_FAUCET_IGNORE_LIST`          | A list of Matrix accounts that will be silently ignored. Example: \"@alice:matrix.org,@bob:domain.com\" | `""`                          |
+| Name                                               | Description                                                                                             | Value                         |
+|----------------------------------------------------|---------------------------------------------------------------------------------------------------------|-------------------------------|
+| `faucet.existingConfigMap`                         | existingConfigMap                                                                                       | `""`                          |
+| `faucet.existingSecret`                            | existingSecret                                                                                          | `""`                          |
+| `faucet.externalAccess`                            | externalAccess                                                                                          | `false`                       |
+| `faucet.secret.SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC` | Mnemonic seed for the faucet account                                                                    | `this is a fake mnemonic`     |
+| `faucet.secret.SMF_CONFIG_RECAPTCHA_SECRET`        | A secret recaptcha token used to validate external requests                                             | `fakeRecaptchaSecret`         |
+| `faucet.secret.SMF_CONFIG_MATRIX_ACCESS_TOKEN`     | Matrix Bot access token                                                                                 | `ThisIsNotARealAccessToken`   |
+| `faucet.config.SMF_CONFIG_NETWORK`                 | Name of the network; matches corresponding config in the code                                           | `rococo`                      |
+| `faucet.config.SMF_CONFIG_MATRIX_SERVER`           | Matrix server URL                                                                                       | `https://matrix.org`          |
+| `faucet.config.SMF_CONFIG_MATRIX_BOT_USER_ID`      | Bot user ID                                                                                             | `@test_bot_faucet:matrix.org` |
+| `faucet.config.SMF_CONFIG_FAUCET_IGNORE_LIST`      | A list of Matrix accounts that will be silently ignored. Example: \"@alice:matrix.org,@bob:domain.com\" | `""`                          |
 
 
 ### Common parameters

--- a/charts/substrate-faucet/ci/kind-values.yaml
+++ b/charts/substrate-faucet/ci/kind-values.yaml
@@ -4,8 +4,13 @@ serviceMonitor:
 faucet:
   secret:
     # your bot access token here is how to find it https://t2bot.io/docs/access_tokens/
+    SMF_CONFIG_MATRIX_ACCESS_TOKEN: "__GITHUB_SECRET_SMF_CONFIG_MATRIX_ACCESS_TOKEN"
+    # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
     SMF_BOT_MATRIX_ACCESS_TOKEN: "__GITHUB_SECRET_SMF_BOT_MATRIX_ACCESS_TOKEN"
   config:
+    SMF_CONFIG_MATRIX_SERVER: "https://m.parity.io"
+    SMF_CONFIG_MATRIX_BOT_USER_ID: "@helm-charts-bot:parity.io"
+    # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
     SMF_BACKEND_RPC_ENDPOINT: "wss://westend-rpc.polkadot.io/"
     SMF_BOT_MATRIX_SERVER: "https://m.parity.io"
     SMF_BOT_MATRIX_BOT_USER_ID: "@helm-charts-bot:parity.io"

--- a/charts/substrate-faucet/templates/deployment.yaml
+++ b/charts/substrate-faucet/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: SMF_CONFIG_PORT
+              value: "5555"
+            # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
             - name: SMF_BACKEND_PORT
               value: "5555"
           {{- range $key, $val := .Values.faucet.secret }}
@@ -47,6 +50,14 @@ spec:
                   key: {{ $key }}
                   name: {{ $.Values.faucet.existingConfigMap | default (printf "%s-config" $.Release.Name) }}
           {{- end }}
+            - name: SMF_CONFIG_DEPLOYED_REF
+              value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            - name: SMF_CONFIG_DEPLOYED_TIME
+              value: {{ now | date "2006-01-02T15:04:05" | quote }}
+            - name: SMF_CONFIG_EXTERNAL_ACCESS
+              value: {{ .Values.faucet.externalAccess | quote }}
+
+            # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
             - name: SMF_BACKEND_DEPLOYED_REF
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             - name: SMF_BACKEND_DEPLOYED_TIME

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -28,6 +28,17 @@ faucet:
   externalAccess: false
 
   secret:
+    ## @param faucet.secret.SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC Mnemonic seed for the faucet account
+    ##
+    SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC: "this is a fake mnemonic"
+    ## @param faucet.secret.SMF_CONFIG_RECAPTCHA_SECRET A secret recaptcha token used to validate external requests
+    ##
+    SMF_CONFIG_RECAPTCHA_SECRET: "fakeRecaptchaSecret"
+    ## @param faucet.secret.SMF_CONFIG_MATRIX_ACCESS_TOKEN Matrix Bot access token
+    ##
+    SMF_CONFIG_MATRIX_ACCESS_TOKEN: "ThisIsNotARealAccessToken"
+
+    # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
     ## @param faucet.secret.SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC Mnemonic seed for the faucet account
     ##
     SMF_BACKEND_FAUCET_ACCOUNT_MNEMONIC: "this is a fake mnemonic"
@@ -39,6 +50,20 @@ faucet:
     SMF_BOT_MATRIX_ACCESS_TOKEN: "ThisIsNotARealAccessToken"
 
   config:
+    ## @param faucet.config.SMF_CONFIG_RPC_ENDPOINT WS RPC node endpoint
+    ##
+    SMF_CONFIG_RPC_ENDPOINT: "wss://example.com/"
+    ## @param faucet.config.SMF_CONFIG_MATRIX_SERVER Matrix server URL
+    ##
+    SMF_CONFIG_MATRIX_SERVER: "https://matrix.org"
+    ## @param faucet.config.SMF_CONFIG_MATRIX_CONFIG_USER_ID Bot user ID
+    ##
+    SMF_CONFIG_MATRIX_BOT_USER_ID: "@test_bot_faucet:matrix.org"
+    ## @param faucet.config.SMF_CONFIG_FAUCET_IGNORE_LIST A list of Matrix accounts that will be silently ignored. Example: \"@alice:matrix.org,@bob:domain.com\"
+    ##
+    SMF_CONFIG_FAUCET_IGNORE_LIST: ''
+
+    # TODO: remove these SMF_BACKEND_* / SMF_BOT_* vars after releasing corresponding faucet code
     ## @param faucet.config.SMF_BACKEND_RPC_ENDPOINT WS RPC node endpoint
     ##
     SMF_BACKEND_RPC_ENDPOINT: "wss://example.com/"


### PR DESCRIPTION
This is part 1 of reworking faucet configs, where we moving static
network info back into code, so we would update it more easily.
However, we don't want to shoot ourselves at the foot, so we're
deploying it in three stages:
1. Add new variables to the configuration
2. Deploy the code (if delployment fails, we can safely rollback and
reiterate)
3. Remove old variables from the configuration
