### PR TITLE
[node] Fix format of relay-chain-rpc-urls

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 4.9.0
+version: 4.9.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -583,8 +583,7 @@ spec:
                 {{- if .Values.node.isParachain }}
                 {{- /* Experimental Feature */}}
                 {{- if  .Values.node.externalRelayChain.enabled }}
-                --relay-chain-rpc-urls {{- range .Values.node.externalRelayChain.relayChainRpcUrls }}
-                "{{ . }}" \
+                --relay-chain-rpc-urls {{- range .Values.node.externalRelayChain.relayChainRpcUrls }} "{{ . }}" {{- end }} \
                 {{- end }}
                 {{- end }}
                 --listen-addr=/ip4/0.0.0.0/tcp/30334 \

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -585,7 +585,6 @@ spec:
                 {{- if  .Values.node.externalRelayChain.enabled }}
                 --relay-chain-rpc-urls {{- range .Values.node.externalRelayChain.relayChainRpcUrls }} "{{ . }}" {{- end }} \
                 {{- end }}
-                {{- end }}
                 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
                 {{- if .Values.node.perNodeServices.paraP2pService.enabled }}
                 {{- if .Values.node.perNodeServices.paraP2pService.ws.enabled }}


### PR DESCRIPTION
Fix the format from:

```
        --relay-chain-rpc-urls
        "wss://xxxx-xxxx.xxxx.io" \
        "wss://yyyy-yyyy.yyyyy.io" \
```

to

```
        --relay-chain-rpc-urls "wss://xxxx-xxxx.xxxx.io" "wss://yyyy-yyyy.yyyyy.io"  \
```