### PR TITLE
Fix pipefail option not supported in node container image

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.0.0
+version: 5.0.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -13,7 +13,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node helm chart
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.0.1](https://img.shields.io/badge/Version-5.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -278,7 +278,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail {{ if .Values.initContainers.persistGeneratedNodeKey.debug }}-x{{ end }}
+              set -eu {{ if .Values.initContainers.persistGeneratedNodeKey.debug }}-x{{ end }}
               NODE_KEY_PATH="/keystore/node-key"
               if [ -f "${NODE_KEY_PATH}" ]; then
                 echo "Node key already exists, skipping node key generation"
@@ -302,7 +302,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
+              set -eu {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
               {{- range $keys := .Values.node.keys }}
               if [ ! -f /var/run/secrets/{{ .type }}/type ]; then
                  echo "Error: File /var/run/secrets/{{ .type }}/type does not exist"
@@ -339,7 +339,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
+              set -eu {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
               {{- range $keys := .Values.node.existingSecrets.keys }}
               if [ ! -f /var/run/secrets/{{ $keys }}/type ]; then
                  echo "Error: File /var/run/secrets/{{ $keys }}/type does not exist"
@@ -372,7 +372,7 @@ spec:
           args:
             - -c
             - |
-              set -eu -o pipefail {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
+              set -eu {{ if .Values.initContainers.injectKeys.debug }}-x{{ end }}
               {{- if .Values.node.vault.nodeKey }}
               NODE_KEY_PATH="/vault/secrets/{{ .Values.node.vault.nodeKey.name }}{{ if .Values.node.vault.nodeKey.vaultKeyAppendPodIndex }}-${HOSTNAME##*-}{{ end }}"
               if [ ! -f ${NODE_KEY_PATH} ]; then


### PR DESCRIPTION
`-o pipefail` is not supported in Polkadot container image. The option was added in v5.0.0. Rolling back this change.