### PR TITLE
Remove faucet SMF_CONFIG_DEPLOYED_TIME env var

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 2.2.1
+version: 2.2.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/templates/deployment.yaml
+++ b/charts/substrate-faucet/templates/deployment.yaml
@@ -49,8 +49,6 @@ spec:
           {{- end }}
             - name: SMF_CONFIG_DEPLOYED_REF
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-            - name: SMF_CONFIG_DEPLOYED_TIME
-              value: {{ now | date "2006-01-02T15:04:05" | quote }}
             - name: SMF_CONFIG_EXTERNAL_ACCESS
               value: {{ .Values.faucet.externalAccess | quote }}
           ports:


### PR DESCRIPTION
This is not a very useful feature to have and it is causing constant redeploys in our ArgoCD deployment every time our git config is has a new commit.