### PR TITLE
Use autoscaling/v2 for clusters that support it in substrate-telemetry

### DIFF
--- a/charts/substrate-telemetry/Chart.yaml
+++ b/charts/substrate-telemetry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "2.2.0"
+version: "2.3.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/substrate-telemetry/templates/shard-hpa.yaml
+++ b/charts/substrate-telemetry/templates/shard-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.shard.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: telemetry-shard


### PR DESCRIPTION
To support [deprecations in Kubernetes 1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26).