### PR TITLE
backup downloading was fixed for node helm chart

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.1.5
+version: 5.1.6
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node helm chart
 
-![Version: 5.1.5](https://img.shields.io/badge/Version-5.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.1.6](https://img.shields.io/badge/Version-5.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -102,25 +102,25 @@ spec:
 
                 if [ "${METHOD}" == "http-single-tar-lz4" ]; then
                   apk add lz4 --no-cache
-                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --stdout --error-on-no-transfer --retries 6 --retries-sleep 10 ${SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /chain-data/chains/${CHAIN_PATH}/
+                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --stdout --retries 1 --error-on-no-transfer --no-gzip-encoding ${SNAPSHOT_URL} | lz4 -c -d - | tar -x -C /chain-data/chains/${CHAIN_PATH}/
                   chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /chain-data/chains/${CHAIN_PATH}/
 
                 elif [ "${METHOD}" == "http-single-tar" ]; then
-                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --stdout --error-on-no-transfer --retries 6 --retries-sleep 10 ${SNAPSHOT_URL} | tar -x -C /chain-data/chains/${CHAIN_PATH}/
+                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --stdout --retries 1 --error-on-no-transfer --no-gzip-encoding ${SNAPSHOT_URL} | tar -x -C /chain-data/chains/${CHAIN_PATH}/
 
                 elif [ "${METHOD}" == "gcs" ]; then
                   LATEST=$(rclone cat {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --quiet :gcs:${SNAPSHOT_URL}/latest_version.meta.txt)
                   if [ -z "$LATEST" ]; then
                     echo "Failed to retrieve latest_version.meta.txt file. Will download everything from ${SNAPSHOT_URL} instead"
                   fi
-                  rclone sync {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --fast-list --transfers $PARALLEL_TRANFERS --progress --retries 6 --retries-sleep 10 --error-on-no-transfer :gcs:${SNAPSHOT_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
+                  rclone sync {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --fast-list --transfers $PARALLEL_TRANFERS --progress --retries 6 --retries-sleep 10 --error-on-no-transfer --inplace --no-gzip-encoding :gcs:${SNAPSHOT_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
 
                 elif [ "${METHOD}" == "s3" ]; then
                   LATEST=$(rclone cat {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --quiet :s3:${SNAPSHOT_URL}/latest_version.meta.txt )
                   if [ -z "$LATEST" ]; then
                     echo "Failed to retrieve latest_version.meta.txt file. Will download everything from ${SNAPSHOT_URL} instead"
                   fi
-                  rclone sync {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --fast-list --transfers $PARALLEL_TRANFERS --progress --retries 6 --retries-sleep 10 --error-on-no-transfer :s3:${SNAPSHOT_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
+                  rclone sync {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --fast-list --transfers $PARALLEL_TRANFERS --progress --retries 6 --retries-sleep 10 --error-on-no-transfer --inplace --no-gzip-encoding :s3:${SNAPSHOT_URL}/${LATEST} /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
 
                 elif [ "${METHOD}" == "http-filelist" ]; then
                   LATEST=$(rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --stdout ${SNAPSHOT_URL}/latest_version.meta.txt )
@@ -129,8 +129,8 @@ spec:
                   else
                     SNAPSHOT_URL="${SNAPSHOT_URL}/${LATEST}"
                   fi
-                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --error-on-no-transfer ${SNAPSHOT_URL}/{{ .Values.node.chainData.chainSnapshot.filelistName }} /tmp/filelist.txt
-                  rclone copy {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --progress --error-on-no-transfer --transfers $PARALLEL_TRANFERS --http-url ${SNAPSHOT_URL} --no-traverse --http-no-head --disable-http2 --retries 6 --retries-sleep 10 --files-from /tmp/filelist.txt :http: /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
+                  rclone copyurl {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --retries 6 --retries-sleep 10 --error-on-no-transfer --inplace --no-gzip-encoding ${SNAPSHOT_URL}/{{ .Values.node.chainData.chainSnapshot.filelistName }} /tmp/filelist.txt
+                  rclone copy {{ .Values.initContainers.downloadChainSnapshot.cmdArgs }} --transfers $PARALLEL_TRANFERS --progress --retries 6 --retries-sleep 10 --error-on-no-transfer --inplace --no-gzip-encoding --http-url ${SNAPSHOT_URL} --no-traverse --http-no-head --disable-http2 --size-only --files-from /tmp/filelist.txt :http: /chain-data/chains/${CHAIN_PATH}/{{ $databasePath }}/
                 fi
               fi
           env:


### PR DESCRIPTION
R2 backups and rclone have some issues in the paritydb case. The main reason is the fact that paritydb uses really big files (up to 40+GB). I spent a couple of days to find all of them. :)

Issues:
* for big files R2 backend can provide the 206 (Partial Content) HTTP code without request from the client side, it is against the protocol specifications. Normally we shouldn't have it on the client side when we use the Cloudflare edge cache. The edge cache has to terminate this answer on its side, cache the whole file and then send it to the client. For some reason, the edge cache sometimes passes the 206 answers from R2 to clients and caches these R2 answers. It leads to the issue when the client tries to download the file next time the client will receive the cached 206 answers from the edge cache, not from R2 backends. It breaks downloads. 206 answers are excluded from the edge cache for now by the cache rule
* since the 1.63.0 version rclone uses the copy strategy by default. It means that it downloads files to a temp directory then copy them and removes the temp files in the end. In the paritydb case when we download big files in parallel mode this strategy leads to using extra space (100+ GB). If we don't have enough free space we will have an endless loading loop as a result. The `--inplace` flag fixes it
* if we use a list of HTTP links to download files we don't have information about the real modification time of files. If rclone has an error it tries to check all already downloaded files before the next attempt, during this check rclone decides to download files again because it finds a modification time difference (files from the 70s) for some reason. We have an endless loading loop as a result. The ` --size-only` flag fixes it
* sometimes rclone has retries because of file size difference errors.  It's essential if we have to download big files. Possibly the `--no-gzip-encoding` flag can reduce the number of these errors, at least it was mentioned as a workaround in some GitHub issues. Also, DB files can't be archived very effetely, it doesn't make sense to use compression on the HTTP level. The flag can save CPU resources.

Other changes:
* it doesn't make sense to use high-level retries when we download a single archived file to a pipe, a high-level retry will brake the pipe. rclone uses 3 high-level retries by default, I disabled it. If the download is failed unarchived files have to be removed by the script, the next download attempts will be performed on the next run on the init container. But rclone performs 10 low-level (HTTP) retries anyway.