### PR TITLE
Switch to using GH App for pushing to gh-pages branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -28,9 +29,16 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
+      - name: Retrieve GH app token
+        id: generate-github-app-token
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.CHART_UPDATER_APP_ID }}
+          private_key: ${{ secrets.CHART_UPDATER_APP_KEY }}
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
         with:
           charts_dir: charts

--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.1.6
+version: 5.1.7
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node helm chart
 
-![Version: 5.1.6](https://img.shields.io/badge/Version-5.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.1.7](https://img.shields.io/badge/Version-5.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 


### PR DESCRIPTION
Fixes too wide permissions on the `gh-pages` branch. Lock down the branch and only allow pushing to it for the GH App.

Bump `node` chart release to test the changes.
