### PR TITLE
Added cloudsql to faucet

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 2.2.2
+version: 3.0.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts
+dependencies:
+  - name: postgresql
+    version: "12.8.3"
+    repository: "https://charts.bitnami.com/bitnami"

--- a/charts/substrate-faucet/README.md
+++ b/charts/substrate-faucet/README.md
@@ -7,11 +7,12 @@ The helm chart installs the [Substrate Matrix faucet](https://github.com/parityt
 To deploy a Westend faucet:
 ```console
 helm repo add parity https://paritytech.github.io/helm-charts/
+helm dependency update
 helm install substrate-faucet parity/substrate-faucet \
     --set faucet.secret.SMF_CONFIG_FAUCET_ACCOUNT_MNEMONIC="//Alice" \
     --set faucet.secret.SMF_CONFIG_MATRIX_ACCESS_TOKEN="******" \
     --set faucet.config.SMF_CONFIG_MATRIX_SERVER="https://matrix.org" \
-    --set faucet.config.SMF_CONFIG_MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org" 
+    --set faucet.config.SMF_CONFIG_MATRIX_BOT_USER_ID="@test_bot_faucet:matrix.org" \
     --set faucet.config.SMF_CONFIG_NETWORK="westend" 
 ```
 

--- a/charts/substrate-faucet/templates/configmap.yaml
+++ b/charts/substrate-faucet/templates/configmap.yaml
@@ -7,4 +7,9 @@ data:
   {{- range $key, $val := .Values.faucet.config }}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
+  POSTGRESQL_HOST: "{{ .Release.Name }}-postgresql"
+  POSTGRESQL_PORT: "5432"
+  POSTGRESQL_USERNAME: postgres
+  POSTGRESQL_DATABASE: postgres
+  POSTGRESQL_SSLMODE: disable
 {{- end }}

--- a/charts/substrate-faucet/templates/deployment.yaml
+++ b/charts/substrate-faucet/templates/deployment.yaml
@@ -33,24 +33,15 @@ spec:
           env:
             - name: SMF_CONFIG_PORT
               value: "5555"
-          {{- range $key, $val := .Values.faucet.secret }}
-            - name: {{ $key }}
-              valueFrom:
-                secretKeyRef:
-                  key: {{ $key }}
-                  name: {{ $.Values.faucet.existingSecret | default (printf "%s-secret" $.Release.Name) }}
-          {{- end }}
-          {{- range $key, $val := .Values.faucet.config }}
-            - name: {{ $key }}
-              valueFrom:
-                configMapKeyRef:
-                  key: {{ $key }}
-                  name: {{ $.Values.faucet.existingConfigMap | default (printf "%s-config" $.Release.Name) }}
-          {{- end }}
             - name: SMF_CONFIG_DEPLOYED_REF
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             - name: SMF_CONFIG_EXTERNAL_ACCESS
               value: {{ .Values.faucet.externalAccess | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ $.Values.faucet.existingConfigMap | default (printf "%s-config" $.Release.Name) }}
+            - secretRef:
+                name: {{ $.Values.faucet.existingSecret | default (printf "%s-secret" $.Release.Name) }}
           ports:
             - name: http
               containerPort: 5555

--- a/charts/substrate-faucet/templates/secret.yaml
+++ b/charts/substrate-faucet/templates/secret.yaml
@@ -8,4 +8,5 @@ data:
   {{- range $key, $val := .Values.faucet.secret }}
   {{ $key }}: {{ $val | b64enc }}
   {{- end }}
+  POSTGRESQL_PASSWORD: {{ .Values.postgresql.global.postgresql.auth.postgresPassword  | b64enc | quote -}}
 {{- end }}

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -125,3 +125,20 @@ ingress:
   ## @param ingress.enabled Specifies whether as Ingress should be created
   ##
   enabled: false
+
+postgresql:
+  global:
+    postgresql:
+      auth:
+        postgresPassword: "Secret!"
+  primary:
+    persistence:
+      storageClass: "ssd-csi"
+      size: 4Gi
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+      requests:
+        cpu: 250m
+        memory: 512Mi

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -133,7 +133,6 @@ postgresql:
         postgresPassword: "Secret!"
   primary:
     persistence:
-      storageClass: "ssd-csi"
       size: 4Gi
     resources:
       limits:


### PR DESCRIPTION
Couldn't find an existing chart here with cloudsql enabled, so I'm not really sure if this is enough on the `helm-charts` side. 

A part of https://github.com/paritytech/polkadot-testnet-faucet/issues/335