### PR TITLE
K8s manifests validation pipeline

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,3 +90,24 @@ jobs:
         --target-branch ${{ github.event.repository.default_branch }} \
         --charts ${{ steps.list-changed.outputs.changed }}
       if: steps.list-changed.outputs.changed
+
+  validate-manifests:
+    runs-on: ubuntu-latest
+    container: docker.io/paritytech/kube-manifests-validation:k8s-1.25.9-gator-3.12.0-datree-1.9.19-9196b4c
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - run: |
+        git config --system --add safe.directory $GITHUB_WORKSPACE
+        git fetch origin "+${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"
+
+    - name: Validate manifests
+      run: |
+        /app/validate-k8s-manifests.sh \
+          --datree-policy-config /app/datree-policies.yaml \
+          --git-ref-changed-paths $GITHUB_BASE_REF \
+          --skip-gatekeeper \
+          charts

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: helm-docs
   args: []
   description: Uses 'helm-docs' to create documentation from the Helm chart's 'values.yaml' file, and inserts the result into a corresponding 'README.md' file.
-  entry: git-hook/helm-docs
+  entry: git-hooks/helm-docs
   files: (README\.md\.gotmpl|(Chart|requirements|values)\.yaml)$
   language: script
   name: Helm Docs


### PR DESCRIPTION
Add Kubernetes manifests validation to the PR pipeline.
Uses `datree` to fetch K8s and CRDs schema from community-maintained repos and run validation against the rendered manifests. See https://github.com/paritytech/k8s-manifests-validation for details.

Closes: https://github.com/paritytech/helm-charts/issues/282