### PR TITLE
Remove duplicate chain and role labels

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.2.1
+version: 5.2.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node helm chart
 
-![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.2.2](https://img.shields.io/badge/Version-5.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -39,8 +39,6 @@ helm.sh/chart: {{ include "node.chart" . }}
 {{ include "node.serviceLabels" . }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-chain: {{ .Values.node.chain }}
-role: {{ .Values.node.role }}
 {{- if or .Values.node.chainData.pruning ( not ( kindIs "invalid" .Values.node.chainData.pruning ) ) }}
 {{- if ge ( int .Values.node.chainData.pruning ) 1 }}
 pruning: {{ .Values.node.chainData.pruning | quote }}


### PR DESCRIPTION
The labels are already set in node.serviceLabels.

This was caught by datree validation:
```
[X] Kubernetes schema validation
❌  k8s schema validation error: error unmarshalling resource: error converting YAML to JSON: yaml: unmarshal errors:
  line 20: key "chain" already set in map
  line 21: key "role" already set in map
```

Labels were rendering like this:
```
    metadata:
      labels:
        helm.sh/chart: node-5.2.1
        app.kubernetes.io/name: node
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: substrate-node
        chain: polkadot
        release: release-name
        role: full
        app.kubernetes.io/version: "latest"
        app.kubernetes.io/managed-by: Helm
        chain: polkadot
        role: full
        pruning: "1000"
        database: rocksdb
```