### PR TITLE
subcommand and args are not quoted together

### DIFF
--- a/charts/bridges-common-relay/Chart.yaml
+++ b/charts/bridges-common-relay/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bridges-common-relay
 description: A Helm chart for bridges-common-relay
 type: application
-version: 0.2.2
+version: 0.2.3
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/bridges-common-relay/README.md
+++ b/charts/bridges-common-relay/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Parity Bridges Common helm chart
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This helm chart installs [Parity Bridges Common](https://github.com/paritytech/parity-bridges-common) relayer.
 

--- a/charts/bridges-common-relay/templates/deployment.yaml
+++ b/charts/bridges-common-relay/templates/deployment.yaml
@@ -34,13 +34,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if .Values.relayHeaders.enabled }}
-            - "relay-headers {{ .Values.relayHeaders.name }}"
+            - "relay-headers"
+            - "{{ .Values.relayHeaders.name }}"
             {{- range $key, $value := .Values.relayHeaders.params }}
             - "--{{ $key }} {{ $value }}"
             {{- end }}
             {{- end }}
             {{- if .Values.relayHeadersAndMessages.enabled }}
-            - "relay-headers-and-messages {{ .Values.relayHeadersAndMessages.name }}"
+            - "relay-headers-and-messages"
+            - "{{ .Values.relayHeadersAndMessages.name }}"
             {{- range $key, $value := .Values.relayHeadersAndMessages.params }}
             {{- if kindIs "slice" $value }}
             {{- range $param := $value }}


### PR DESCRIPTION
## Problem Description

When using a Dockerfile with an `ENTRYPOINT` set to `<relayer_bin>`, the Helm chart was causing issues because it passed subcommands in the form `'subcommand param'`. This resulted in execution errors like:
```
error: The subcommand 'relay-headers rococo-to-bridge-hub-wococo' wasn't recognized
	Did you mean 'relay-headers'?

If you believe you received this message in error, try re-running with 'laos-relay -- relay-headers rococo-to-bridge-hub-wococo'

USAGE:
    laos-relay <SUBCOMMAND>

For more information try --help
```

## Temporary Workaround

The temporary workaround was to use a wrapping script as the `ENTRYPOINT` in the Dockerfile. This script allows us to pass any arguments to the `<relayer_bin>` without modification or shell interpretation.

Example of the wrapping script:

```bash
#!/bin/bash
set -xeu
/usr/bin/laos-relay $@
``` 
## Solution Proposed in this PR
This Pull Request aims to remove the need for the wrapping script while maintaining backward compatibility with the current usage.