### PR TITLE
Remove cpu limit for the faucet postgres container

### DIFF
--- a/charts/substrate-faucet/Chart.yaml
+++ b/charts/substrate-faucet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: substrate-faucet
 description: A Helm chart to deploy substrate-faucet
 type: application
-version: 3.0.1
+version: 3.0.2
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/substrate-faucet/README.md
+++ b/charts/substrate-faucet/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate faucet Helm chart
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -206,15 +206,14 @@ Adding default global override for .org.matrix.msc3786.rule.room.server_acl
 | nameOverride | string | `""` | String to partially override common.names.name |
 | nodeSelector | object | `{}` | Node labels for pods assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | podSecurityContext | object | `{}` | Pods Security Context ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
-| postgresql | object | `{"global":{"postgresql":{"auth":{"database":"faucet","postgresPassword":"Secret!"}}},"primary":{"persistence":{"size":"4Gi"},"resources":{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}}}` | PostgreSQL configuration |
+| postgresql | object | `{"global":{"postgresql":{"auth":{"database":"faucet","postgresPassword":"Secret!"}}},"primary":{"persistence":{"size":"4Gi"},"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}}}` | PostgreSQL configuration |
 | postgresql.global.postgresql.auth | object | `{"database":"faucet","postgresPassword":"Secret!"}` | Auth configuration |
 | postgresql.global.postgresql.auth.database | string | `"faucet"` | Database name |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"Secret!"` | Database password |
-| postgresql.primary | object | `{"persistence":{"size":"4Gi"},"resources":{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}}` | Primary PostgreSQL configuration |
+| postgresql.primary | object | `{"persistence":{"size":"4Gi"},"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}}` | Primary PostgreSQL configuration |
 | postgresql.primary.persistence | object | `{"size":"4Gi"}` | Storage configuration |
 | postgresql.primary.persistence.size | string | `"4Gi"` | Storage size |
-| postgresql.primary.resources | object | `{"limits":{"cpu":"500m","memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Resources requests/limits for the container |
-| postgresql.primary.resources.limits.cpu | string | `"500m"` | CPU limit |
+| postgresql.primary.resources | object | `{"limits":{"memory":"1024Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Resources requests/limits for the container |
 | postgresql.primary.resources.limits.memory | string | `"1024Mi"` | Memory limit |
 | postgresql.primary.resources.requests.cpu | string | `"250m"` | CPU requests |
 | postgresql.primary.resources.requests.memory | string | `"512Mi"` | Memory requests |

--- a/charts/substrate-faucet/values.yaml
+++ b/charts/substrate-faucet/values.yaml
@@ -107,7 +107,7 @@ postgresql:
     resources:
       limits:
         # -- CPU limit
-        cpu: 500m
+        #cpu: 500m
         # -- Memory limit
         memory: 1024Mi
       requests:


### PR DESCRIPTION
Remove the cpu limit for postgres as those are generally not good practice and cause `CPUThrottlingHigh` alerts in our infrastructure.

See: https://home.robusta.dev/blog/stop-using-cpu-limits