### PR TITLE
Switch environment to main in GH Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: main
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Switch environment to main in release GH Action to properly handle credentials.