### PR TITLE
[CI] Add CR_SKIP_EXISTING in chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,5 +41,6 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
+          CR_SKIP_EXISTING: true
         with:
           charts_dir: charts


### PR DESCRIPTION
Regardless of whether the chart is updated or not (e.g., README or CI updates), the pipeline always creates a helm release based from the tag. Here are examples of failed pipelines resulting from this behavior:

https://github.com/paritytech/helm-charts/actions/runs/6785695811/job/18444581159
https://github.com/paritytech/helm-charts/actions/runs/6826428489/job/18566340637

To address these issues, this variable enables skipping the creation of the chart if it already exists.