### PR TITLE
[node] Add Optional dnsPolicy Configuration 

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.5.0
+version: 5.5.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.5.1](https://img.shields.io/badge/Version-5.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -244,6 +244,7 @@ If you're running a collator node:
 | autoscaling.minReplicas | int | `1` | Maintain min number of replicas |
 | autoscaling.targetCPU | string | `nil` | Target CPU utilization that triggers scale up |
 | autoscaling.targetMemory | string | `nil` | Target memory utilization that triggers scale up |
+| dnsPolicy | string | `""` | Field dnsPolicy can be set to 'ClusterFirst', 'Default', 'None', or 'ClusterFirstWithHostNet' or '' to not specify dnsPolicy and let Kubernetes use its default behavior |
 | extraContainers | list | `[]` | Additional containers to run in the pod |
 | extraInitContainers | list | `[]` | Additional init containers to run in the pod |
 | extraLabels | object | `{}` | Additional common labels on pods and services |

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -78,6 +78,9 @@ spec:
       labels:
       {{- include "node.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -674,8 +674,7 @@ jaegerAgent:
 # -- Annotations to add to the Pod
 podAnnotations: {}
 
-# dnsPolicy can be set to 'ClusterFirst', 'Default', 'None', or 'ClusterFirstWithHostNet'
-# Leave it empty to not specify dnsPolicy and let Kubernetes use its default behavior
+# -- Field dnsPolicy can be set to 'ClusterFirst', 'Default', 'None', or 'ClusterFirstWithHostNet' or '' to not specify dnsPolicy and let Kubernetes use its default behavior
 dnsPolicy: ""
 
 # -- Define which Nodes the Pods are scheduled on

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -674,6 +674,10 @@ jaegerAgent:
 # -- Annotations to add to the Pod
 podAnnotations: {}
 
+# dnsPolicy can be set to 'ClusterFirst', 'Default', 'None', or 'ClusterFirstWithHostNet'
+# Leave it empty to not specify dnsPolicy and let Kubernetes use its default behavior
+dnsPolicy: ""
+
 # -- Define which Nodes the Pods are scheduled on
 nodeSelector: {}
 


### PR DESCRIPTION
## Problem

In certain Kubernetes deployments, the default dnsPolicy of ClusterFirst can cause issues with the resolution of external domain names. This problem was particularly evident with telemetry endpoints, where nodes were unable to establish connections due to DNS resolution failures, defaulting to Kubernetes' internal DNS service (e.g., *.svc.cluster.local).

## Proposed solution

This pull request introduces an optional configuration option dnsPolicy for nodes in the Helm charts. This change aims to address an issue where nodes running inside Kubernetes environments fail to properly resolve external URLs, specifically telemetry URLs, due to the default dnsPolicy setting.



