### PR TITLE
Bump K8s schema for manifests validation to 1.28.5

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -116,7 +116,7 @@ jobs:
 
   validate-manifests:
     runs-on: ubuntu-latest
-    container: docker.io/paritytech/kube-manifests-validation:k8s-1.25.9-gator-3.12.0-datree-1.9.19-9196b4c
+    container: docker.io/paritytech/kube-manifests-validation:k8s-1.28.5-gator-3.12.0-datree-1.9.19-261faca
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
- Bump K8s schema for manifests validation to 1.28.5
- The change in https://github.com/paritytech/k8s-manifests-validation/pull/2 should fix the pipeline in https://github.com/paritytech/helm-charts/pull/322