### PR TITLE
[node] Add default ingress rule

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.8.0
+version: 5.9.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.8.0](https://img.shields.io/badge/Version-5.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.9.0](https://img.shields.io/badge/Version-5.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -302,10 +302,11 @@ If you're running a collator node:
 | image.repository | string | `"parity/polkadot"` | Image repository |
 | image.tag | string | `"latest"` | Image tag |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images. ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"annotations":{},"enabled":false,"rules":[],"tls":[]}` | Creates an ingress resource |
+| ingress | object | `{"annotations":{},"enabled":false,"host":"chart-example.local","rules":[],"tls":[]}` | Creates an ingress resource |
 | ingress.annotations | object | `{}` | Annotations to add to the Ingress |
 | ingress.enabled | bool | `false` | Enable creation of Ingress |
-| ingress.rules | list | `[]` | Ingress rules configuration |
+| ingress.host | string | `"chart-example.local"` | hostname used for default rpc ingress rule, if .Values.ingress.rules is set host is not used. |
+| ingress.rules | list | `[]` | Ingress rules configuration, empty = default rpc rule (send all requests to rps port) |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | object | `{"downloadChainSnapshot":{"cmdArgs":"","debug":false,"extraEnvVars":[],"image":{"repository":"docker.io/rclone/rclone","tag":"latest"},"resources":{}},"downloadChainspec":{"debug":false,"image":{"repository":"docker.io/alpine","tag":"latest"},"resources":{}},"downloadRuntime":{"debug":false,"image":{"repository":"paritytech/kubetools-kubectl","tag":"latest"},"resources":{}},"injectKeys":{"debug":false,"resources":{}},"persistGeneratedNodeKey":{"debug":false,"resources":{}},"retrieveServiceInfo":{"debug":false,"image":{"repository":"paritytech/kubetools-kubectl","tag":"latest"},"resources":{}}}` | Additional init containers |
 | initContainers.downloadChainSnapshot.cmdArgs | string | `""` | Flags to add to the CLI command. We rely on rclone for downloading snapshots so make sure the flags are compatible. |

--- a/charts/node/examples/local-rococo/bootnode.yaml
+++ b/charts/node/examples/local-rococo/bootnode.yaml
@@ -26,23 +26,14 @@ node:
     - "--allow-private-ipv4"
     - "--discover-local"
 
+# RPC endpoint
 ingress:
   enabled: false
   annotations:
     kubernetes.io/ingress.class: TODO
     external-dns.alpha.kubernetes.io/target: TODO
     cert-manager.io/cluster-issuer: TODO
-  rules:
-    - host: local-rococo.example.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: bootnode
-                port:
-                  number: 9944
+  host: local-rococo.example.com
   tls:
     - secretName: local-rococo.example.com
       hosts:

--- a/charts/node/examples/local-rococo/parachain.yaml
+++ b/charts/node/examples/local-rococo/parachain.yaml
@@ -38,23 +38,15 @@ node:
     flags:
       - "--allow-private-ipv4"
       - "--discover-local"
+
+# RPC endpoint
 ingress:
   enabled: false
   annotations:
     kubernetes.io/ingress.class: TODO
     external-dns.alpha.kubernetes.io/target: TODO
     cert-manager.io/cluster-issuer: TODO
-  rules:
-    - host: parachain.example.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: parachain-node
-                port:
-                  number: 9944
+  host: parachain.example.com
   tls:
     - secretName: parachain.example.com
       hosts:

--- a/charts/node/templates/ingress.yaml
+++ b/charts/node/templates/ingress.yaml
@@ -19,8 +19,21 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   rules:
-  {{- with .Values.ingress.rules }}
-  {{- toYaml . | nindent 6 }}
+  {{- if .Values.ingress.rules  }}
+    {{- with .Values.ingress.rules }}
+    {{- (tpl (toYaml .) $)  | nindent 6 }}
+    {{- end }}
+  {{- else }}
+    - host: "{{ .Values.ingress.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .Values.node.perNodeServices.apiService.rpcPort }}
   {{- end }}
   tls:
   {{- with .Values.ingress.tls }}

--- a/charts/node/templates/ingress.yaml
+++ b/charts/node/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
     {{- (tpl (toYaml .) $)  | nindent 6 }}
     {{- end }}
   {{- else }}
-    - host: "{{ .Values.ingress.host }}"
+    - host: "{{ tpl .Values.ingress.host . }}"
       http:
         paths:
           - path: /

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -135,7 +135,9 @@ ingress:
   annotations: {}
   #  kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: "true"
-  # -- Ingress rules configuration
+  # -- hostname used for default rpc ingress rule, if .Values.ingress.rules is set host is not used.
+  host: chart-example.local
+  # -- Ingress rules configuration, empty = default rpc rule (send all requests to rps port)
   rules: []
   #  - host: chart-example.local
   #    paths:


### PR DESCRIPTION
Fixes: https://github.com/paritytech/helm-charts/issues/308

To expose RPC, now 2 lines are enough:

```yaml
ingress:
  enabled: true
  host: rpc.example.com
```

Depending on your ingress, you may want to add `annotations` and `tls`.

This changes are backward compatible.