### PR TITLE
[node] fix labels

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.11.0
+version: 5.11.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.11.0](https://img.shields.io/badge/Version-5.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.11.1](https://img.shields.io/badge/Version-5.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Overview
 The Polkadot Helm Chart provides a convenient way to deploy and manage a Polkadot blockchain node in a Kubernetes cluster.

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "node.chart" . }}
 {{ include "node.selectorLabels" . }}
 {{ include "node.serviceLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | replace ":" "-" | replace "@" "_" | trunc 63 | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if or .Values.node.chainData.pruning ( not ( kindIs "invalid" .Values.node.chainData.pruning ) ) }}
 {{- if ge ( int .Values.node.chainData.pruning ) 1 }}


### PR DESCRIPTION
Fixes https://github.com/paritytech/helm-charts/issues/350


If docker tag is more than 64 characters or has Invalid value, deployment will fail. 
values:
```
image:
  repository: parity/polkadot
  tag:latest@sha256:8bc39c8a98eef9d063241ad0f8527ef7922794757edd30da2e3308f720bd1b61
```
Error: 
```
Error: UPGRADE FAILED: cannot patch "bootnode" with kind ServiceAccount: ServiceAccount "bootnode" is invalid: [metadata.labels: Invalid value: "latest@sha256:8bc39c8a98eef9d063241ad0f8527ef7922794757edd30da2e3308f720bd1b61": must be no more than 63 characters, metadata.labels: Invalid value: "latest@sha256:8bc39c8a98eef9d063241ad0f8527ef7922794757edd30da2e3308f720bd1b61": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')] 
```
