### PR TITLE
[node] add params validation

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.11.1
+version: 5.12.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.11.1](https://img.shields.io/badge/Version-5.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.12.0](https://img.shields.io/badge/Version-5.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Overview
 The Polkadot Helm Chart provides a convenient way to deploy and manage a Polkadot blockchain node in a Kubernetes cluster.

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -121,3 +121,44 @@ Return true if we have a Relaychain, a single Relaychain, or if it's part of a c
 {{- else -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Function to validate that exclusive keys are defined only once
+Parameters:
+- $params: list of parameters to validate
+*/}}
+{{- define "validateExclusiveKeys" -}}
+{{- $params := .params -}}
+{{- $global := .global -}}
+
+{{- $countSet := 0 -}}
+{{- $setKeys := "" -}}
+{{- range $param := $params -}}
+  {{- $isSet := tpl (printf "{{ if %s }}true{{ end }}" $param) $global -}}
+  {{- if $isSet -}}
+    {{- $countSet = add1 $countSet -}}
+    {{- $setKeys = printf "%s %s" $setKeys $param -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if gt $countSet 1 -}}
+  {{- fail (printf "Error: Only one of [%s] can be set." $setKeys) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+validate node keys params
+*/}}
+{{- define "validateNodeKeys" -}}
+{{- $nodeKeysParams := list ".Values.node.persistGeneratedNodeKey" ".Values.node.vault.nodeKey" ".Values.node.existingSecrets.nodeKey" ".Values.node.customNodeKey" -}}
+{{- include "validateExclusiveKeys" (dict "params" $nodeKeysParams "global" . ) -}}
+{{- end -}}
+
+{{/*
+validate keys params
+*/}}
+{{- define "validateKeys" -}}
+{{- $keysParams := list ".Values.node.vault.keys" ".Values.node.existingSecrets.keys" ".Values.node.keys" -}}
+{{- include "validateExclusiveKeys" (dict "params" $keysParams "global" . ) -}}
+{{- end -}}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -4,6 +4,8 @@
 {{ $serviceAccountName :=  include "node.serviceAccountName" . }}
 {{ $databasePath := include "node.databasePath" . }}
 {{ $chartManagedFlagsRegex := include "node.chartManagedFlagsRegex" . }}
+{{ include "validateNodeKeys" . }}
+{{ include "validateKeys" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Fixes for: https://github.com/paritytech/helm-charts/issues/349

**Changes:**

- Deployment will fail if the node keys or ID are defined multiple times.

**Example of error:**
```yaml
# examples/local-rococo/bootnode.yaml
node:
  customNodeKey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  persistGeneratedNodeKey: true
```

```shell
helm upgrade --install bootnode . -f examples/local-rococo/bootnode.yaml
Error: UPGRADE FAILED: execution error at (node/templates/statefulset.yaml:7:3): Error: Only one of [ .Values.node.persistGeneratedNodeKey .Values.node.customNodeKey] can be set.
```

**Fix:** Remove either `.Values.node.persistGeneratedNodeKey` or `.Values.node.customNodeKey` from the custom values file (e.g., `-f examples/local-rococo/bootnode.yaml`).
