### PR TITLE
[node] incorrect value for --public-addr if service type is LoadBalancer

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.13.0
+version: 5.13.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.13.0](https://img.shields.io/badge/Version-5.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.13.1](https://img.shields.io/badge/Version-5.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Overview
 The Polkadot Helm Chart provides a convenient way to deploy and manage a Polkadot blockchain node in a Kubernetes cluster.

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -432,7 +432,7 @@ spec:
             - mountPath: /keystore
               name: chain-keystore
         {{- end }}
-        {{- if or (eq .Values.node.perNodeServices.relayP2pService.type "NodePort") (eq .Values.node.perNodeServices.paraP2pService.type "NodePort") .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
+        {{- if or (has .Values.node.perNodeServices.relayP2pService.type (list "NodePort" "LoadBalancer")) (has .Values.node.perNodeServices.paraP2pService.type (list "NodePort" "LoadBalancer")) .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
         - name: retrieve-service-info
           image: {{ .Values.initContainers.retrieveServiceInfo.image.repository }}:{{ .Values.initContainers.retrieveServiceInfo.image.tag }}
           command: [ "/bin/sh" ]
@@ -441,7 +441,7 @@ spec:
             - |
               set -eu -o pipefail {{ if .Values.initContainers.retrieveServiceInfo.debug }}-x{{ end }}
               POD_INDEX="${HOSTNAME##*-}"
-              {{- if and .Values.node.perNodeServices.relayP2pService.enabled (include "node.hasRelaychain" .) (eq .Values.node.perNodeServices.relayP2pService.type "NodePort") }}
+              {{- if and .Values.node.perNodeServices.relayP2pService.enabled (include "node.hasRelaychain" .) (has .Values.node.perNodeServices.relayP2pService.type (list "NodePort" "LoadBalancer") ) }}
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[?(@.name=="p2p")].nodePort}')"
               {{- if .Values.node.perNodeServices.relayP2pService.ws.enabled }}
               RELAY_CHAIN_P2P_PORT_WS="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-relay-chain-p2p -o jsonpath='{.spec.ports[?(@.name=="ws")].nodePort}')"
@@ -452,7 +452,7 @@ spec:
               echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-relay-chain-p2p"
               echo "Saved ${RELAY_CHAIN_P2P_PORT} to /chain-data/relay_chain_p2p_port"
               {{- end }}
-              {{- if and .Values.node.isParachain .Values.node.perNodeServices.paraP2pService.enabled  (eq .Values.node.perNodeServices.paraP2pService.type "NodePort") }}
+              {{- if and .Values.node.isParachain .Values.node.perNodeServices.paraP2pService.enabled  (has .Values.node.perNodeServices.paraP2pService.type (list "NodePort" "LoadBalancer")) }}
               PARA_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-para-chain-p2p -o jsonpath='{.spec.ports[0].nodePort}')"
               echo "${PARA_CHAIN_P2P_PORT}" > /chain-data/para_chain_p2p_port
               echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-para-chain-p2p, saved ${PARA_CHAIN_P2P_PORT} to /chain-data/para_chain_p2p_port"
@@ -491,8 +491,8 @@ spec:
               echo "EXTERNAL_IP=${EXTERNAL_IP}"
               {{- end }}
               {{- if (include "node.hasRelaychain" .) }}
-              {{- if and .Values.node.perNodeServices.relayP2pService.enabled (eq .Values.node.perNodeServices.relayP2pService.type "NodePort")  }}
-              {{- /* For NodePort services, set the p2p port to the value saved in the retrieve-service-info init container */}}
+              {{- if and .Values.node.perNodeServices.relayP2pService.enabled (has .Values.node.perNodeServices.relayP2pService.type (list "NodePort" "LoadBalancer"))  }}
+              {{- /* For NodePort and LoadBalancer services, set the p2p port to the value saved in the retrieve-service-info init container */}}
               RELAY_CHAIN_P2P_PORT="$(cat /chain-data/relay_chain_p2p_port)"
               echo "RELAY_CHAIN_P2P_PORT=${RELAY_CHAIN_P2P_PORT}"
               {{- if .Values.node.perNodeServices.relayP2pService.ws.enabled }}
@@ -500,7 +500,7 @@ spec:
               echo "RELAY_CHAIN_P2P_PORT_WS=${RELAY_CHAIN_P2P_PORT_WS}"
               {{- end }}
               {{- else }}
-              {{- /* For non NodePort services, set the p2p port to value configured in `relayP2pService.port`*/}}
+              {{- /* For non NodePort/LoadBalancer services, set the p2p port to value configured in `relayP2pService.port`*/}}
               RELAY_CHAIN_P2P_PORT={{ $.Values.node.perNodeServices.relayP2pService.port | quote }}
               echo "RELAY_CHAIN_P2P_PORT=${RELAY_CHAIN_P2P_PORT}"
               {{- if .Values.node.perNodeServices.relayP2pService.ws.enabled }}
@@ -510,8 +510,8 @@ spec:
               {{- end }}
               {{- end }}
               {{- if .Values.node.isParachain }}
-              {{- if and .Values.node.perNodeServices.paraP2pService.enabled  (eq .Values.node.perNodeServices.paraP2pService.type "NodePort") }}
-              {{- /* For NodePort services, set the p2p port to the value saved in the retrieve-service-info init container */}}
+              {{- if and .Values.node.perNodeServices.paraP2pService.enabled  (has .Values.node.perNodeServices.paraP2pService.type (list "NodePort" "LoadBalancer")) }}
+              {{- /* For NodePort and LoadBalancer services, set the p2p port to the value saved in the retrieve-service-info init container */}}
               PARA_CHAIN_P2P_PORT="$(cat /chain-data/para_chain_p2p_port)"
               echo "PARA_CHAIN_P2P_PORT=${PARA_CHAIN_P2P_PORT}"
               {{- if .Values.node.perNodeServices.paraP2pService.ws.enabled }}
@@ -519,7 +519,7 @@ spec:
               echo "PARA_CHAIN_P2P_PORT_WS=${PARA_CHAIN_P2P_PORT_WS}"
               {{- end }}
               {{- else }}
-              {{- /* For non NodePort services, set the p2p port to value configured in `paraP2pService.port` */}}
+              {{- /* For non NodePort/LoadBalancer services, set the p2p port to value configured in `paraP2pService.port` */}}
               PARA_CHAIN_P2P_PORT={{ $.Values.node.perNodeServices.paraP2pService.port | quote }}
               echo "PARA_CHAIN_P2P_PORT=${PARA_CHAIN_P2P_PORT}"
               {{- if .Values.node.perNodeServices.paraP2pService.ws.enabled }}


### PR DESCRIPTION
Fixes: https://github.com/paritytech/helm-charts/issues/277


```
--public-addr=/ip4/${EXTERNAL_IP}/tcp/${PARA_CHAIN_P2P_PORT}
```

Before fix:
```
--public-addr=/ip4/external_k8s_node_ip/tcp/30333
```
after fix:
```
--public-addr=/ip4/external_k8s_node_ip/tcp/NodePort
```