### PR TITLE
fix app.kubernetes.io/version

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.13.2
+version: 5.13.3
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/templates/_helpers.tpl
+++ b/charts/node/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "node.chart" . }}
 {{ include "node.selectorLabels" . }}
 {{ include "node.serviceLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | replace ":" "-" | replace "@" "_" | trunc 63 | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | replace ":" "-" | replace "@" "_" | trunc 63 | trimSuffix "-" | trimSuffix "_" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if or .Values.node.chainData.pruning ( not ( kindIs "invalid" .Values.node.chainData.pruning ) ) }}
 {{- if ge ( int .Values.node.chainData.pruning ) 1 }}


### PR DESCRIPTION
If we have `-` or `_` in the end after the `trunc` function applying it will fail rendering.