### PR TITLE
fix example

### DIFF
--- a/charts/node/examples/local-rococo/bootnode.yaml
+++ b/charts/node/examples/local-rococo/bootnode.yaml
@@ -49,7 +49,8 @@ extraInitContainers:
     args:
       - -c
       - |
-        apt update && apt install -y jq
+        apt update || true
+        apt install -y jq
         {{ .Values.node.command }} build-spec --chain {{ .Values.node.chain }} > base.json
         echo '{"bootNodes":["/dns/bootnode-0/tcp/30333/p2p/12D3KooWRpzRTivvJ5ySvgbFnPeEE6rDhitQKL1fFJvvBGhnenSk"]}' > override1.json
         jq  -s '.[0] * .[1]' base.json override1.json | sed 's/1e+18/1000000000000000000/' > plain.json


### PR DESCRIPTION
fix for error:

```
k logs bootnode-0 chainspec-generator

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Get:2 https://releases.parity.io/deb release InRelease [1208 B]
Get:3 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Err:2 https://releases.parity.io/deb release InRelease
  The following signatures were invalid: EXPKEYSIG CDF6F188B6D4484C Parity Security Team <security@parity.io>
Get:4 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.7 kB]
Get:5 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [3275 kB]
Get:6 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [2424 kB]
Get:7 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1164 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [2700 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [3353 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [51.8 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1452 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [81.4 kB]
Get:19 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [33.7 kB]
Reading package lists...
W: GPG error: https://releases.parity.io/deb release InRelease: The following signatures were invalid: EXPKEYSIG CDF6F188B6D4484C Parity Security Team <security@parity.io>
E: The repository 'https://releases.parity.io/deb release InRelease' is not signed.
2024-11-13 12:22:31 Building chain spec
/bin/bash: line 4: jq: command not found
Error:
   0: Invalid input: Error parsing spec file: EOF while parsing a value at line 1 column 0

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                 ⋮ 1 frame hidden ⋮
   2: polkadot::main::h7359f9e4080eb99a
      at <unknown source file>:<unknown line>
   3: std::sys::backtrace::__rust_begin_short_backtrace::h59c7b7c1f932b5b4
      at <unknown source file>:<unknown line>
   4: main<unknown>
      at <unknown source file>:<unknown line>
   5: __libc_start_main<unknown>
      at <unknown source file>:<unknown line>
   6: _start<unknown>
      at <unknown source file>:<unknown line>

Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
Run with RUST_BACKTRACE=full to include source snippets.

```