### PR TITLE
[common] add template for ingress

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A generic helm chart for Kubernetes
 type: application
-version: 0.8.1
+version: 0.9.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -46,14 +46,13 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 | image.repository | string | `"nginx"` | Image repository |
 | image.tag | string | `"latest"` | Image tag |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"annotations":{},"className":"","enabled":false,"rules":[{"host":"chart-example.local","http":{"paths":[{"path":"/","pathType":"ImplementationSpecific"}]}}],"tls":[{"hosts":["chart-example.local"],"secretName":"chart-example-tls"}]}` | Creates an ingress resource |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"host":"chart-example.local","rules":[{"host":"{{ .Values.ingress.host }}","http":{"paths":[{"backend":{"service":{"name":"{{ include \"common.fullname\" . }}","port":{"name":"http"}}},"path":"/","pathType":"ImplementationSpecific"}]}}],"tls":[]}` | Creates an ingress resource |
 | ingress.annotations | object | `{}` | Annotations to add to the Ingress |
 | ingress.className | string | `""` | Ingress class name |
 | ingress.enabled | bool | `false` | Enable creation of Ingress |
-| ingress.rules | list | `[{"host":"chart-example.local","http":{"paths":[{"path":"/","pathType":"ImplementationSpecific"}]}}]` | A list of hosts for the Ingress |
-| ingress.tls | list | `[{"hosts":["chart-example.local"],"secretName":"chart-example-tls"}]` | Ingress TLS configuration |
-| ingress.tls[0] | object | `{"hosts":["chart-example.local"],"secretName":"chart-example-tls"}` | Secrets to use for TLS configuration |
-| ingress.tls[0].hosts | list | `["chart-example.local"]` | A list of hosts for the Ingress with TLS enabled |
+| ingress.host | string | `"chart-example.local"` | Hostname used for the default ingress rule. If .Values.ingress.rules is set, this host is not used. |
+| ingress.rules | list | `[{"host":"{{ .Values.ingress.host }}","http":{"paths":[{"backend":{"service":{"name":"{{ include \"common.fullname\" . }}","port":{"name":"http"}}},"path":"/","pathType":"ImplementationSpecific"}]}}]` | Ingress rules configuration. The default rule sends all requests to the HTTP port of the default service. |
+| ingress.tls | list | `[]` | Ingress TLS configuration. Leave empty for no TLS. |
 | livenessProbe | object | `{}` | Controller Container liveness probe configuration ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | nameOverride | string | `""` | Provide a name in place of node for `app:` labels |
 | namespaceOverride | string | `""` | Provide a name to substitute for the full names of resources |

--- a/charts/common/templates/ingress.yaml
+++ b/charts/common/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   rules:
   {{- with .Values.ingress.rules }}
-  {{- toYaml . | nindent 4 }}
+  {{- (tpl (toYaml .) $) | nindent 4 }}
   {{- end }}
   tls:
   {{- with .Values.ingress.tls }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -135,25 +135,27 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # -- A list of hosts for the Ingress
+  # -- Hostname used for the default ingress rule. If .Values.ingress.rules is set, this host is not used.
+  host: chart-example.local
+  # -- Ingress rules configuration. The default rule sends all requests to the HTTP port of the default service.
   rules:
-    - host: chart-example.local
+    - host: "{{ .Values.ingress.host }}"
       http:
         paths:
           - path: /
             pathType: ImplementationSpecific
-            # backend:
-            #   service:
-            #     name: signet-frontend
-            #     port:
-            #       name: http
-  # -- Ingress TLS configuration
-  tls:
-  # -- Secrets to use for TLS configuration
-  - secretName: chart-example-tls
-    # -- A list of hosts for the Ingress with TLS enabled
-    hosts:
-      - chart-example.local
+            backend:
+              service:
+                name: {{ include "common.fullname" . }}
+                port:
+                  name: http
+  # -- Ingress TLS configuration. Leave empty for no TLS.
+  tls: []
+  # -- Secrets to use for TLS configuration.
+  # - secretName: chart-example-tls
+  #   # -- A list of hosts for the Ingress with TLS enabled.
+  #   hosts:
+  #     - chart-example.local
 
 # -- Resource limits & requests
 resources: {}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -146,7 +146,7 @@ ingress:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "common.fullname" . }}
+                name: '{{ include "common.fullname" . }}'
                 port:
                   name: http
   # -- Ingress TLS configuration. Leave empty for no TLS.


### PR DESCRIPTION
It is useful to template ingress rules so that, between environments, only the host changes while the backend configuration remains the same.

Changes:
1. Add template to the ingress rule.
2. Remove invalid default value for TLS.
3. Bump Helm chart version.