### PR TITLE
[node] add option to generate node keys

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.14.0
+version: 5.15.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.14.0](https://img.shields.io/badge/Version-5.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.15.0](https://img.shields.io/badge/Version-5.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Overview
 The Polkadot Helm Chart provides a convenient way to deploy and manage a Polkadot blockchain node in a Kubernetes cluster.
@@ -428,7 +428,7 @@ If you're running a collator node:
 | node.customChainspec | bool | `false` | Use the file defined in `node.customChainspecPath` as the chainspec. Ensure that the file is either mounted or generated with an init container. |
 | node.customChainspecPath | string | `"/chain-data/chainspec.json"` | Node may require custom name for chainspec file. ref:  moonbeam https://github.com/PureStake/moonbeam/issues/1104#issuecomment-996787548 Note: path should start with /chain-data/ since this folder mount in init container download-chainspec. |
 | node.customChainspecUrl | string | `nil` | URL to retrive custom chain spec |
-| node.customNodeKey | list | `[]` | List of the custom node key(s) for all pods in statefulset. |
+| node.customNodeKey | list | `[]` | List of custom node key(s) for all pods in the StatefulSet Alternatively, use `.seed` to derive node key(s). |
 | node.enableOffchainIndexing | bool | `false` | Enable Offchain Indexing. https://docs.substrate.io/fundamentals/offchain-operations/ |
 | node.enableSidecarLivenessProbe | bool | `false` | Enable Node liveness probe through `paritytech/ws-health-exporter` running as a sidecar container |
 | node.enableSidecarReadinessProbe | bool | `false` | Enable Node readiness probe through `paritytech/ws-health-exporter` running as a sidecar container |

--- a/charts/node/ci/dev-rpc-values.yaml
+++ b/charts/node/ci/dev-rpc-values.yaml
@@ -54,5 +54,8 @@ wsHealthExporter:
 terminationGracePeriodSeconds: 10
 
 substrateApiSidecar:
+  image:
+    repository: parity/substrate-api-sidecar
+    tag: v19.1.0
   metrics:
     enabled: true

--- a/charts/node/ci/ginkgo/node_suite_test.go
+++ b/charts/node/ci/ginkgo/node_suite_test.go
@@ -23,7 +23,7 @@ const (
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
-	flag.IntVar(&timeoutSeconds, "timeout", 300, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 600, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/charts/node/ci/ginkgo/node_suite_test.go
+++ b/charts/node/ci/ginkgo/node_suite_test.go
@@ -23,7 +23,7 @@ const (
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&namespace, "namespace", "", "namespace where the application is running")
-	flag.IntVar(&timeoutSeconds, "timeout", 600, "timeout in seconds")
+	flag.IntVar(&timeoutSeconds, "timeout", 300, "timeout in seconds")
 	timeout = time.Duration(timeoutSeconds) * time.Second
 }
 

--- a/charts/node/templates/customNodeKeySecret.yaml
+++ b/charts/node/templates/customNodeKeySecret.yaml
@@ -6,11 +6,17 @@ kind: Secret
 metadata:
   name: {{ $fullname }}-custom-node-key
 data:
-{{- if  eq ( typeOf .Values.node.customNodeKey ) "string" }}
+{{- if kindIs "string" .Values.node.customNodeKey }}
   custom-node-key: {{ .Values.node.customNodeKey | mustRegexFind "^[0-9a-zA-Z]{64}$" | b64enc }}
-{{- else }}
-{{- range $index, $key := .Values.node.customNodeKey }}
+{{- else if kindIs "slice" .Values.node.customNodeKey }}
+  {{- range $index, $key := .Values.node.customNodeKey }}
   custom-node-key-{{ $index }}: {{ $key | mustRegexFind "^[0-9a-zA-Z]{64}$" | b64enc }}
-{{- end }}
+  {{- end }}
+{{- else if kindIs "map" .Values.node.customNodeKey }}
+  {{- range $index := until (max .Values.autoscaling.maxReplicas .Values.node.replicas | int) }}
+  custom-node-key-{{ $index }}: {{ printf "%s/%s/%d" $.Values.node.customNodeKey.seed (default $fullname $.Values.node.customNodeKey.extraDerivation) $index | sha256sum | mustRegexFind "^[0-9a-zA-Z]{64}$" | b64enc }}
+  {{- end }}
+{{- else }}
+  {{- fail (printf "ERROR: '.Values.node.customNodeKey' is invalid. Expected type 'string', 'slice', or 'map', but got: '%s'" (kindOf .Values.node.customNodeKey)) }}
 {{- end }}
 {{ end }}

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -603,9 +603,9 @@ spec:
                 --node-key-file /keystore/node-key \
                 {{- else if .Values.node.customNodeKey }}
                 {{- if  eq ( typeOf .Values.node.customNodeKey ) "string" }}
-                --node-key $(cat /custom-node-key/custom-node-key) \
+                --node-key-file /custom-node-key/custom-node-key \
                 {{- else }}
-                --node-key $(cat /custom-node-key/custom-node-key-${POD_INDEX}) \
+                --node-key-file /custom-node-key/custom-node-key-${POD_INDEX} \
                 {{- end }}
                 {{- else if .Values.node.existingSecrets.nodeKey }}
                 --node-key $(cat /custom-node-key/{{ .Values.node.existingSecrets.nodeKey.secretKey }}{{ if .Values.node.existingSecrets.nodeKey.appendPodIndex }}-${POD_INDEX}{{ end }}) \

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -432,8 +432,22 @@ node:
 
   # -- If enabled, generate a persistent volume to use for the keys
   persistGeneratedNodeKey: false
-  # -- List of the custom node key(s) for all pods in statefulset.
+  # -- List of custom node key(s) for all pods in the StatefulSet
+  # Alternatively, use `.seed` to derive node key(s).
   customNodeKey: []
+  #
+  # Example configurations:
+  # customNodeKey:
+  #   - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  #   - bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  #
+  # OR
+  #
+  # customNodeKey:
+  #   seed: "Any secure, long, random string of at least 64 characters"
+  #   extraDerivation: ""  # Optional. The `extraDerivation` value (default: release name)
+  #                         # and pod index will be appended to the seed to derive a new node key.
+
 
   # -- Expose metrics via Prometheus format in /metrics endpoint.
   # Passes the following args to the Polkadot binary:


### PR DESCRIPTION
The chart already has the `persistGeneratedNodeKey` option to generate node keys. These keys are random and stored on disk. They are not known before deployment, so they cannot be used for testnet bootnode deployments.  

### Changes:  
1. Add an option to generate node keys within helm secrets.  
2. Replace `--node-key $(cat /path/to/key)` with `--node-key-file /path/to/key`. This is more secure, as the key is not exposed in the `ps` output. `cat` was previously used to fix the newline issue at the end of the file. Keys stored in Helm secrets do not have a trailing newline.