### PR TITLE
node StatefulSet: add partition functionality

### DIFF
--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -31,6 +31,7 @@ spec:
     {{- if eq .Values.node.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
       maxUnavailable: {{ .Values.node.updateStrategy.maxUnavailable  | default 1 }}
+      partition: {{ .Values.node.updateStrategy.partition | default 0 }}
     {{- end }}
    {{- end }}
   template:

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -169,6 +169,11 @@ node:
     type: "RollingUpdate"
     # -- Can be an int or a %
     maxUnavailable: 1
+    # -- Partitions/Instances to rollout the changes to
+    # -- 0 means all pods
+    # -- 1 means first pod onwards (i.e. if 4 replicas run, issue an update
+    # -- to pods 1, 2 and 3)
+    partition: 0
 
   # -- Use the file defined in `node.customChainspecPath` as the chainspec. Ensure that the file is either mounted or generated with an init container.
   customChainspec: false


### PR DESCRIPTION
Adds an option to provide the `partition` parameter. This parameter is used to select the pods to apply the rolling upgrade to. More information on the parameter can be found [here](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions). 

_Note: The default argument does not break the current configuration._