### PR TITLE
[common] feature add

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A generic helm chart for Kubernetes
 type: application
-version: 0.10.0
+version: 0.11.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -69,9 +69,9 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 | replicaCount | int | `1` | Number of replicas for the pod |
 | resources | object | `{}` | Resource limits & requests |
 | secrets | object | `{}` | Creates a secret resource The value must be base64 encoded |
-| service | object | `{"annotations":{},"ports":null,"sessionAffinity":"","type":"ClusterIP"}` | Creates a service resource |
+| service | object | `{"annotations":{},"ports":[],"sessionAffinity":"","type":"ClusterIP"}` | Creates a service resource |
 | service.annotations | object | `{}` | Annotations to add to the Service resource |
-| service.ports | string | `nil` | Ports to expose on the service |
+| service.ports | list | `[]` | Ports to expose on the service |
 | service.sessionAffinity | string | `""` | Session Affinitiy type |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account for the pod to use ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -14,7 +14,9 @@ spec:
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}
+  {{- if .Values.service.ports }}
   ports:
 {{ toYaml .Values.service.ports | indent 4 }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}
+  {{- end }}

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -14,10 +14,8 @@ spec:
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- end }}
-  {{- if .Values.service.ports }}
   ports:
 {{ toYaml .Values.service.ports | indent 4 }}
-  {{- end }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}
 

--- a/charts/common/templates/service.yaml
+++ b/charts/common/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   {{- if .Values.service.ports }}
   ports:
 {{ toYaml .Values.service.ports | indent 4 }}
+  {{- end }}
   selector:
     {{- include "common.selectorLabels" . | nindent 4 }}
-  {{- end }}
+

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -115,7 +115,7 @@ service:
   # -- Session Affinitiy type
   sessionAffinity: ""
   # -- Ports to expose on the service
-  ports:
+  ports: []
     # - name: http
     #   port: 80
     #   targetPort: 8080


### PR DESCRIPTION
The common helm chart errors when `ports:` is not defined. The PR sets the missing default value.