### PR TITLE
Add netbird NetworkResource to the `common` chart

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A generic helm chart for Kubernetes
 type: application
-version: 0.12.0
+version: 0.13.0
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -56,6 +56,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 | livenessProbe | object | `{}` | Controller Container liveness probe configuration ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | nameOverride | string | `""` | Provide a name in place of node for `app:` labels |
 | namespaceOverride | string | `""` | Provide a name to substitute for the full names of resources |
+| netbird | object | `{}` | Expose the Service over NetBird via the netbird kubernetes-operator (requires a netbird.io/v1alpha1 NetworkRouter in the cluster) |
 | nodeSelector | object | `{}` | Define which Nodes the Pods are scheduled on. |
 | persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"size":"50Gi"}` | If enabled, creates a PVC and mounts it on /data and deploys the pod as statefulset |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | PVC access mode |

--- a/charts/common/templates/networkresource.yaml
+++ b/charts/common/templates/networkresource.yaml
@@ -1,0 +1,26 @@
+{{- with .Values.netbird }}
+{{- if .expose }}
+{{- /* Exposes the app Service over NetBird via the netbird kubernetes-operator
+       (netbird.io/v1alpha1 flow): the operator creates a NetBird network
+       resource for the Service ClusterIP plus an A record <svc>.<ns>.<zone>
+       in the NetworkRouter's DNS zone. Requires a NetworkRouter deployed in
+       the cluster and the destination groups to exist (Group CRs). */}}
+apiVersion: netbird.io/v1alpha1
+kind: NetworkResource
+metadata:
+  name: {{ .serviceName | default (include "common.fullname" $) }}
+  namespace: {{ template "common.namespace" $ }}
+  labels:
+    {{- include "common.labels" $ | nindent 4 }}
+spec:
+  networkRouterRef:
+    name: {{ .routerName | default "router" }}
+    namespace: {{ .routerNamespace | default "netbird-operator" }}
+  serviceRef:
+    name: {{ .serviceName | default (include "common.fullname" $) }}
+  groups:
+    {{- range .groups }}
+    - name: {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/common/templates/networkresource.yaml
+++ b/charts/common/templates/networkresource.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "common.labels" $ | nindent 4 }}
 spec:
   networkRouterRef:
-    name: {{ .routerName | default "router" }}
+    name: {{ required "netbird.routerName is required (NetworkRouters are named after their cluster)" .routerName }}
     namespace: {{ .routerNamespace | default "netbird-operator" }}
   serviceRef:
     name: {{ .serviceName | default (include "common.fullname" $) }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -288,3 +288,13 @@ cloudsql:
     targetPort: 5432
   commandline:
     args: "-instances=gcp-project-id:zone:instance-name=tcp:0.0.0.0:5432"
+
+# -- Expose the Service over NetBird via the netbird kubernetes-operator
+# (requires a netbird.io/v1alpha1 NetworkRouter in the cluster)
+netbird: {}
+#  expose: true
+#  groups:               # NetBird destination groups (must exist / Group CRs)
+#    - my-group
+#  serviceName: ""       # defaults to common.fullname
+#  routerName: "router"
+#  routerNamespace: "netbird-operator"

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -296,5 +296,5 @@ netbird: {}
 #  groups:               # NetBird destination groups (must exist / Group CRs)
 #    - my-group
 #  serviceName: ""       # defaults to common.fullname
-#  routerName: "router"
+#  routerName: "my-cluster"  # mandatory, NetworkRouters are named after their cluster
 #  routerNamespace: "netbird-operator"


### PR DESCRIPTION
Feature to expose service to the netbird network with a `common` helm chart with new `NetworkResource` crd

```
netbird: {}
#  expose: true
#  groups:               # NetBird destination groups (must exist / Group CRs)
#    - my-group
#  serviceName: ""       # defaults to common.fullname
#  routerName: "my-cluster"  # mandatory, NetworkRouters are named after their cluster
```