### PR TITLE
add uniform checks for hasCollatorRelaychain

### DIFF
--- a/charts/node/Chart.yaml
+++ b/charts/node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: A Helm chart to deploy Substrate/Polkadot nodes
 type: application
-version: 5.17.0
+version: 5.17.1
 maintainers:
   - name: Parity
     url: https://github.com/paritytech/helm-charts

--- a/charts/node/README.md
+++ b/charts/node/README.md
@@ -18,7 +18,7 @@ This is intended behaviour. Make sure to run `git add -A` once again to stage ch
 
 # Substrate/Polkadot node Helm chart
 
-![Version: 5.17.0](https://img.shields.io/badge/Version-5.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.17.1](https://img.shields.io/badge/Version-5.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Overview
 The Polkadot Helm Chart provides a convenient way to deploy and manage a Polkadot blockchain node in a Kubernetes cluster.

--- a/charts/node/templates/statefulset.yaml
+++ b/charts/node/templates/statefulset.yaml
@@ -234,7 +234,7 @@ spec:
             runAsUser: 0
           {{- end }}
         {{- end }}
-        {{- if or .Values.node.customChainspecUrl (or .Values.node.collatorRelayChain.customChainspecUrl .Values.node.collatorLightClient.relayChainCustomChainspecUrl) }}
+        {{- if or .Values.node.customChainspecUrl (or (and .Values.node.collatorRelayChain.customChainspecUrl (include "node.hasCollatorRelaychain" .)) .Values.node.collatorLightClient.relayChainCustomChainspecUrl) }}
         - name: download-chainspec
           image: {{ .Values.initContainers.downloadChainspec.image.repository }}:{{ .Values.initContainers.downloadChainspec.image.tag }}
           command: [ "/bin/sh" ]
@@ -251,7 +251,7 @@ spec:
               fi
               {{- end }}
               {{- end }}
-              {{- if .Values.node.collatorRelayChain.customChainspecUrl }}
+              {{- if and .Values.node.collatorRelayChain.customChainspecUrl (include "node.hasCollatorRelaychain" .) }}
               {{- if not .Values.node.forceDownloadChainspec }}
               if [ ! -f {{ .Values.node.collatorRelayChain.customChainspecPath}} ]; then
               {{- end }}


### PR DESCRIPTION
Adds uniform checks for the `node.hasCollatorRelaychain` key. It ignores the field for relay chain nodes provisioned by the chart.

In the existing setup, providing the value to relay chain nodes gives an invalid init container that tries to download parachain data to the volume attached to the container. 
